### PR TITLE
chore(promo): add Remotion promo-render tool (tools/promo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,13 @@ docs/57-grid-placement-and-mobile-fixes.md
 docs/57-library-production-cleanup.md
 docs/58-homepage-preview-alignment-and-height.md
 docs/59-homepage-art-direction-pass.md
+# Remotion render intermediates (internal promo tool)
+tools/promo/out/
+
+# Rendered promo media — regenerable via tools/promo (npm run render / render:social).
+# Kept out of git history to avoid binary bloat; the channel doc + captions
+# (assets/promo/README.md) and the tool source stay tracked. Distribute the
+# rendered files via a GitHub Release or upload them natively when posting.
+assets/promo/*.gif
+assets/promo/*.mp4
+assets/promo/*.png

--- a/assets/promo/README.md
+++ b/assets/promo/README.md
@@ -1,0 +1,55 @@
+# Promo asset kit
+
+Rendered by [`tools/promo/`](../../tools/promo/README.md) (`npm run render` for GIFs, `npm run render:social` for this kit). Channel rules, timing, and the full launch sequence live in [`LAUNCH.md`](../../LAUNCH.md) — this file only maps assets to channels and gives paste-ready captions.
+
+All claims match LAUNCH.md's fact sheet (56 components + 8 blocks → "60+ components & blocks"; free & open source; shadcn-registry install). Never add user counts or download numbers to a caption.
+
+## Which asset where
+
+| Asset | Format | Built for | Notes |
+| --- | --- | --- | --- |
+| `motiq-trailer.mp4` | 16:9 · 1280×720 · ~32s | **X launch post**, LinkedIn, YouTube, docs page | Upload natively (never link). Designed for muted autoplay: text carries the story, product moves from frame 0, no logo cold-open. |
+| `motiq-card.png` | 1200×675 static | X image posts, link-preview style shares, blog headers | Pair with a short text post when video feels too heavy. |
+| `motiq-square.mp4` / `.gif` | 1:1 · 1080×1080 · 12s loop | X follow-ups, LinkedIn feed, Instagram, Threads | Loops seamlessly; good for drip posts. |
+| `motiq-vertical.mp4` | 9:16 · 1080×1920 · 12s | YouTube Shorts, Reels, TikTok | Short-form discovery channel; re-post monthly. |
+| `motiq-intro/-install/-showcase/-pillars/-free.gif` | 16:9 GIFs | GitHub README, dev.to posts, Reddit inline | README hero = intro or install. |
+| `motiq-cat-*.gif` (11) | 16:9 GIFs | Drip engine: one category per post; docs pages; Reddit niche subs | Match the sub: `motiq-cat-ai` → AI-adjacent subs, `motiq-cat-developer-tools` → r/devtools etc. |
+| `tools/promo/out/*.mp4` | source MP4s of every GIF | Anywhere video beats GIF | X re-encodes GIFs to video anyway — prefer the MP4. |
+
+## Paste-ready captions
+
+**X — launch post (attach `motiq-trailer.mp4`):**
+> Stop building UI animation from scratch.
+>
+> I built Motiq — 60+ animated React & shadcn components and blocks. Accessible, reduced-motion safe, RSC-safe, installed as editable source into your repo.
+>
+> 100% free & open source. No signup.
+>
+> motiq.dev
+
+**X — drip post (attach one `motiq-cat-*.gif`'s MP4, rotate categories, 2–3×/week):**
+> [Category] components for [use case], animated and production-ready.
+>
+> `npx shadcn add https://motiq.dev/r/<component>`
+>
+> Free & open source → motiq.dev
+
+**Reddit — r/reactjs or r/SideProject (native video upload of trailer or a category MP4, text-post framing per LAUNCH.md):**
+> **I built a free library of 60+ animated React/shadcn components — all editable source, no paywall**
+>
+> After rebuilding the same animated cards/streams/checkout flows for the third client, I turned them into a catalog. Everything installs through the shadcn registry as plain source you own — no npm dependency, no lock-in. Accessibility and prefers-reduced-motion are handled on every component.
+>
+> It's fully free and open source. I'd genuinely love feedback on the API surface and what categories are missing.
+>
+> GitHub: github.com/RMahammad/motiq · Docs: motiq.dev
+
+**r/webdev:** Showoff Saturday megathread only — same copy, shorter.
+
+**LinkedIn (attach trailer or square loop):**
+> Shipping polished UI motion is still weirdly hard: engineers hand-roll animations, then accessibility and reduced-motion get skipped under deadline. I built Motiq to fix that — 60+ production-ready animated React components, free and open source, installed as editable source through the shadcn registry. motiq.dev
+
+## Rules of thumb (from research — sources in LAUNCH.md)
+
+- **X**: native MP4, 15–60s, one idea per post, CTA in the text not just the video; muted autoplay means on-screen text does the selling.
+- **Reddit**: authenticity beats polish — "I built this + specific feedback ask" framing, native uploads, reply to every comment (including skeptics), respect the 9:1 participation ratio.
+- **Everywhere**: show the product moving in the first 3 seconds; never open on a logo; never invent stats.

--- a/docs/07-remotion-strategy.md
+++ b/docs/07-remotion-strategy.md
@@ -3,6 +3,8 @@
 > **Type:** 🟢 Canonical for the Remotion product line & rendering flow · **Implementation status:** 🔵 Planned (Phase 4 — gated) · **Last reviewed:** 2026-07-14
 > **Related:** [`08-remotion-license-analysis.md`](08-remotion-license-analysis.md) (⚠️ read first) · [ADR-0003](adrs/0003-remotion-boundary.md) · [`03-architecture.md`](03-architecture.md) · [`remotion-composition-authoring` skill](../.claude/skills/remotion-composition-authoring/SKILL.md)
 > ⚠️ **Do not build any of this until the license questions in [`08`](08-remotion-license-analysis.md) are answered in writing.** This is the Phase-4 gate.
+>
+> **Internal marketing use (2026-07-18):** [`tools/promo/`](../tools/promo/README.md) uses Remotion to render our own promo GIFs (`assets/promo/`). This is local rendering by an individual under Remotion's free tier — it does not redistribute the Player, render for customers, or ship Remotion code, so it does not trip the Phase-4 gate. It lives outside the workspace and is not part of this product line.
 
 ## Product boundaries
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,8 @@ export default [
       "**/*.stories.tsx",
       "**/vitest.setup.ts",
       "docs/**",
+      // Internal marketing render tool (own toolchain, not product code).
+      "tools/promo/**",
     ],
   },
   ...boundaries,

--- a/tools/promo/README.md
+++ b/tools/promo/README.md
@@ -1,0 +1,58 @@
+# Motiq promo renderer (internal)
+
+Internal marketing tool that renders the promo GIFs in [`assets/promo/`](../../assets/promo/) with Remotion. It is **not** part of the product packages: it lives outside the pnpm workspace (plain `npm install`), is excluded from the root ESLint run, and nothing in `packages/*` or `apps/*` may import it.
+
+## License note (recorded 2026-07-18)
+
+This tool only renders our own marketing videos locally, by an individual — covered by Remotion's free tier for individuals/≤3-person orgs (see [`docs/08-remotion-license-analysis.md`](../../docs/08-remotion-license-analysis.md)). It does not redistribute `@remotion/player`, render for customers, or ship Remotion code to buyers, so the Phase-4 license gate is not triggered. Re-check that doc before expanding this tool's scope.
+
+## Usage
+
+```bash
+cd tools/promo
+npm install
+npm run studio              # live-edit compositions in Remotion Studio
+npm run render              # render all 5 GIFs to assets/promo/
+npm run render -- motiq-intro   # render a single composition
+npm run test:determinism    # same props -> identical frame hashes
+```
+
+Requires `ffmpeg` on PATH (used for the two-pass palette GIF encode).
+
+## Compositions
+
+All 1200×675 @ 30 fps; GIFs are encoded at 960 px wide, 20 fps, infinite loop.
+
+| ID | Content |
+| --- | --- |
+| `motiq-intro` | Brand intro: logomark, kinetic wordmark, tagline |
+| `motiq-install` | Terminal typing `npx shadcn add https://motiq.dev/r/spotlight-card` → live component pops in |
+| `motiq-showcase` | "60+ production-ready components" grid with live micro-demos |
+| `motiq-pillars` | Production-ready pillars: accessible, reduced-motion, SSR/RSC, editable source |
+| `motiq-free` | Free & open source CTA with GitHub star button |
+| `motiq-cat-product-backgrounds` | Category: Workflow Topology Field, Queue Pulse Lanes, Data Contour Surface |
+| `motiq-cat-workflow-heroes` | Category: Agent Operations / Deployment Control / Live Data Command heroes |
+| `motiq-cat-ai` | Category: AI Response Stream, Tool Call Activity, Prompt Composer |
+| `motiq-cat-developer-tools` | Category: Deployment Pipeline, Live Log Stream, Environment Switcher |
+| `motiq-cat-collaboration` | Category: Live Presence Stack, Comment Thread, Approval Workflow |
+| `motiq-cat-data-motion` | Category: KPI Number Morph, Streaming Data Rows, Filter Result Transition |
+| `motiq-cat-productivity` | Category: Kanban Card Movement, Task Dependency Map, Project Timeline |
+| `motiq-cat-file-workflows` | Category: File Upload Pipeline, Multi-file Queue, Processing Timeline |
+| `motiq-cat-commerce` | Category: Product Variant Selector, Cart Item Transition, Checkout Progress |
+| `motiq-cat-security` | Category: Passkey Setup Flow, Two-Factor Setup Flow, Session Security Center |
+| `motiq-cat-communication` | Category: Message Delivery States, Typing and Presence, Thread Expansion |
+
+Category GIF tile labels must stay in sync with real component names in `apps/docs/lib/catalog.ts`.
+
+## Social kit (`npm run render:social`)
+
+| ID | Output | Format |
+| --- | --- | --- |
+| `motiq-trailer` | `motiq-trailer.mp4` | 16:9 1280×720, ~32s — hook → 4 category scenes → install → pillars → free/open outro. Built for muted autoplay (X/LinkedIn native upload). |
+| `motiq-square` | `motiq-square.mp4` + `.gif` | 1:1 1080×1080, 12s loop for feeds |
+| `motiq-vertical` | `motiq-vertical.mp4` | 9:16 1080×1920, 12s for Shorts/Reels/TikTok |
+| `motiq-card` | `motiq-card.png` | 1200×675 static for X image posts / link cards |
+
+Channel mapping + paste-ready captions: [`assets/promo/README.md`](../../assets/promo/README.md). Claim discipline: quantities must match the fact sheet in `LAUNCH.md` ("60+ components & blocks", never invented stats).
+
+Brand colors/copy are mirrored from `packages/tokens/styles.css` (dark theme) and `product.config.json` into [`src/theme.ts`](src/theme.ts) — update there if the brand changes. All animation is deterministic (`useCurrentFrame()`-derived; seeded PRNG for particles), enforced by `npm run test:determinism`.

--- a/tools/promo/package-lock.json
+++ b/tools/promo/package-lock.json
@@ -1,0 +1,2919 @@
+{
+  "name": "motiq-promo-videos",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "motiq-promo-videos",
+      "version": "0.0.0",
+      "dependencies": {
+        "@remotion/cli": "4.0.491",
+        "@remotion/google-fonts": "4.0.491",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "remotion": "4.0.491",
+        "zod": "4.3.6"
+      },
+      "devDependencies": {
+        "@types/react": "^19.0.0",
+        "typescript": "^5.7.3"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
+      "integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
+      "license": "MIT",
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
+      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mediabunny/aac-encoder": {
+      "version": "1.50.8",
+      "resolved": "https://registry.npmjs.org/@mediabunny/aac-encoder/-/aac-encoder-1.50.8.tgz",
+      "integrity": "sha512-A5Se/LZd6RmYq/h36lBMSEsHvsyW8d0toR7FrAwpsFYbK+DVQYf90KiBT1Aw/mzLXx8/ypIOORJnd1sVZqOvJQ==",
+      "license": "MPL-2.0",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      },
+      "peerDependencies": {
+        "mediabunny": "^1.0.0"
+      }
+    },
+    "node_modules/@mediabunny/flac-encoder": {
+      "version": "1.50.8",
+      "resolved": "https://registry.npmjs.org/@mediabunny/flac-encoder/-/flac-encoder-1.50.8.tgz",
+      "integrity": "sha512-4cfN03SbEoQaG+eBeYFUAb1R1ALaAHzf43dXFzQTr/oO5ueqzTgBoG3coKrIvBaAMU7Vv36mrBKLX8bvTppdAQ==",
+      "license": "MPL-2.0",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      },
+      "peerDependencies": {
+        "mediabunny": "^1.0.0"
+      }
+    },
+    "node_modules/@mediabunny/mp3-encoder": {
+      "version": "1.50.8",
+      "resolved": "https://registry.npmjs.org/@mediabunny/mp3-encoder/-/mp3-encoder-1.50.8.tgz",
+      "integrity": "sha512-eBT/H30tTu8AmZXqZ5RTpJ9VmwVlwednajuOrrWp0GS6cbGXsGMQ60Qvr3ZMIE0QDiadlEzb8/ozR+doP+MC1g==",
+      "license": "MPL-2.0",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      },
+      "peerDependencies": {
+        "mediabunny": "^1.0.0"
+      }
+    },
+    "node_modules/@module-federation/error-codes": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.22.0.tgz",
+      "integrity": "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/runtime": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.22.0.tgz",
+      "integrity": "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.22.0",
+        "@module-federation/runtime-core": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/runtime-core": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.22.0.tgz",
+      "integrity": "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/runtime-tools": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.22.0.tgz",
+      "integrity": "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.22.0",
+        "@module-federation/webpack-bundler-runtime": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/sdk": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.22.0.tgz",
+      "integrity": "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/webpack-bundler-runtime": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.22.0.tgz",
+      "integrity": "sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
+      "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.5.0",
+        "@emnapi/runtime": "^1.5.0",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@remotion/bundler": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/bundler/-/bundler-4.0.491.tgz",
+      "integrity": "sha512-cZ1qLKjvEZWLjZ+3NxyMeg1BS9Tgr7XedqWnhU26+cOdOlfAfjLddjjT+f43Kzz9kuOwJkC1mokXA2r+xKtLlQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@remotion/media-parser": "4.0.491",
+        "@remotion/studio": "4.0.491",
+        "@remotion/studio-shared": "4.0.491",
+        "@remotion/timeline-utils": "4.0.491",
+        "@rspack/core": "1.7.11",
+        "@rspack/plugin-react-refresh": "1.6.1",
+        "css-loader": "7.1.4",
+        "esbuild": "0.28.1",
+        "react-refresh": "0.18.0",
+        "remotion": "4.0.491",
+        "style-loader": "4.0.0",
+        "webpack": "5.105.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/canvas-capture": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/canvas-capture/-/canvas-capture-4.0.491.tgz",
+      "integrity": "sha512-3Jsd93mSKdVBVC/tyI24DMWGe77h2JFdHUSgS1K1NzHlGKrjWxQOAN+ld59LpRaw2KHBlFrOX8uO5EnEdq09vw==",
+      "license": "Remotion License",
+      "dependencies": {
+        "mediabunny": "1.50.8",
+        "remotion": "4.0.491"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/cli": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/cli/-/cli-4.0.491.tgz",
+      "integrity": "sha512-n7rSRV75bkDmuCTwIsTJahRMlfhmGErHAio5DV07xT4uFUHquIevYOHkJ/KN2RFoLd1r+ohuBoNmhK4M02gqaQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@remotion/bundler": "4.0.491",
+        "@remotion/media-utils": "4.0.491",
+        "@remotion/player": "4.0.491",
+        "@remotion/renderer": "4.0.491",
+        "@remotion/studio": "4.0.491",
+        "@remotion/studio-server": "4.0.491",
+        "@remotion/studio-shared": "4.0.491",
+        "dotenv": "17.3.1",
+        "minimist": "1.2.6",
+        "prompts": "2.4.2",
+        "remotion": "4.0.491"
+      },
+      "bin": {
+        "remotion": "remotion-cli.js",
+        "remotionb": "remotionb-cli.js",
+        "remotiond": "remotiond-cli.js"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/compositor-darwin-arm64": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-arm64/-/compositor-darwin-arm64-4.0.491.tgz",
+      "integrity": "sha512-MMBSyxsFHsWA/tsi0QazkhWWOCTnDwPYrrSxZkXpGqByHV6XB+cyRLoSHtX63/eNealrxPcd3jlzK/ND2FSRwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@remotion/compositor-darwin-x64": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-x64/-/compositor-darwin-x64-4.0.491.tgz",
+      "integrity": "sha512-wYiLdqvQ+l0GzObtuprNOYW7msxtVQww/MeXz4Ga52gAcAtzeZmIeQZypV4DiN6gXOWOd+h/5QaLFCdAvr1x4A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-arm64-gnu": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-gnu/-/compositor-linux-arm64-gnu-4.0.491.tgz",
+      "integrity": "sha512-HRO9JRcGVJK4Rl7+2hapkZSEqrlqwiJOCjNxQLl/ybUSrID/8VLzw6860lCAWOzAbqcmdN2E83h8ZSxVXh6anA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-arm64-musl": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-musl/-/compositor-linux-arm64-musl-4.0.491.tgz",
+      "integrity": "sha512-RbWohXwz3HSGf15pUDPj2ywBBKlXfHJ0MjH7RHN77ztu9/DVB0TUrvbmFBK1980wtxwTBxfqFUfV3ljX0uRRyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-x64-gnu": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-gnu/-/compositor-linux-x64-gnu-4.0.491.tgz",
+      "integrity": "sha512-6B7+a4ak4pzFeO7rJGRFebDAKnDRCFsInTqfrpyw/rUK8o0M3qYhipxjZqTYSQAkX5JIFKKiCOprOxP6YdQBdw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-x64-musl": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-musl/-/compositor-linux-x64-musl-4.0.491.tgz",
+      "integrity": "sha512-S+w8VL2F96sJVxxxQgmvMRpKVEz68e24hDtl/cg8oLfRvnUqz8/EENN1Fg3t0iadXQIHv+YEHBOuXjr3aELINQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-win32-x64-msvc": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-win32-x64-msvc/-/compositor-win32-x64-msvc-4.0.491.tgz",
+      "integrity": "sha512-hIdPhMa3X4hQzKA1dl1dkGp2Cq/PsT/DPLIjxHOq6imPqMtfjQ/3Y95B7LNGpjz7Hgewf10/eO5celkHP1rj3w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@remotion/google-fonts": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/google-fonts/-/google-fonts-4.0.491.tgz",
+      "integrity": "sha512-dyLBWYxzLggxGU/nNLJNtwqZZxb4Pvzrk37JIbha6sNfdGwFxuAN1TBBFBMgxmaS2hybo7ZkBfXjgNw+EgQjig==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "remotion": "4.0.491"
+      }
+    },
+    "node_modules/@remotion/licensing": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/licensing/-/licensing-4.0.491.tgz",
+      "integrity": "sha512-oMPGLdGnwVUgkzi1f3Aqu7H80piOF+MDsm9BqYigMTsuivpwdBvqagl2Q8SfuWQdkzTyjK/wQLbcidUAvIFijw==",
+      "license": "MIT"
+    },
+    "node_modules/@remotion/media-parser": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/media-parser/-/media-parser-4.0.491.tgz",
+      "integrity": "sha512-24T2fAehxlVfN7Uh+S4mBsdR72s8OE3Td2hPkOvczPcplYUtodcbjkYM1LrtG7yrYpQYP1y8JJSHVbssty0qMA==",
+      "license": "Remotion License https://remotion.dev/license"
+    },
+    "node_modules/@remotion/media-utils": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/media-utils/-/media-utils-4.0.491.tgz",
+      "integrity": "sha512-4MQvJReTYT0I17FXFXU4rdXGYaHP5F3fNCjkjYUAX0/L3CqsGAFKXucjqMByj1mrA2OgxdardBiyhWzlS98tXg==",
+      "license": "MIT",
+      "dependencies": {
+        "mediabunny": "1.50.8",
+        "remotion": "4.0.491"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/player": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.491.tgz",
+      "integrity": "sha512-MLbcxjudrO+Re9svNGRktoej7n+cHsp/3J/TctkW5UA7tVSH7Rtesmyj0GzHzX5NlHzV6MrN1iE17JLWJfLgmw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "remotion": "4.0.491"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/renderer": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/renderer/-/renderer-4.0.491.tgz",
+      "integrity": "sha512-thGoCol/4P6iJcQRqtuCxxaC2KzaFkhEYOG3SNcVZjbEptIiQjkfEoI+cYs491z1e1RE5QVFAEBYzyhHmD0PDg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@remotion/licensing": "4.0.491",
+        "@remotion/streaming": "4.0.491",
+        "execa": "5.1.1",
+        "remotion": "4.0.491",
+        "source-map": "0.8.0-beta.0",
+        "ws": "8.21.0"
+      },
+      "optionalDependencies": {
+        "@remotion/compositor-darwin-arm64": "4.0.491",
+        "@remotion/compositor-darwin-x64": "4.0.491",
+        "@remotion/compositor-linux-arm64-gnu": "4.0.491",
+        "@remotion/compositor-linux-arm64-musl": "4.0.491",
+        "@remotion/compositor-linux-x64-gnu": "4.0.491",
+        "@remotion/compositor-linux-x64-musl": "4.0.491",
+        "@remotion/compositor-win32-x64-msvc": "4.0.491"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/streaming": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/streaming/-/streaming-4.0.491.tgz",
+      "integrity": "sha512-6f6CsH0AGYxn7HOCqVApCS0PeNl1R00G1FMtBeYxdi/rj496OMxfZ3FztMt+Vuu6FT5Pp9jsg7UFksyN7qrxOQ==",
+      "license": "MIT"
+    },
+    "node_modules/@remotion/studio": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/studio/-/studio-4.0.491.tgz",
+      "integrity": "sha512-03VBYOAIjQYiQ7NsxFxOLmXK2IXH4YhJjtaDeNy90whJZG/gRZ9StWLIayLi4UchA1LS5qoNXmnKX8yRHhwXjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@remotion/canvas-capture": "4.0.491",
+        "@remotion/media-utils": "4.0.491",
+        "@remotion/player": "4.0.491",
+        "@remotion/renderer": "4.0.491",
+        "@remotion/studio-shared": "4.0.491",
+        "@remotion/timeline-utils": "4.0.491",
+        "@remotion/web-renderer": "4.0.491",
+        "@remotion/zod-types": "4.0.491",
+        "mediabunny": "1.50.8",
+        "memfs": "3.4.3",
+        "open": "8.4.2",
+        "remotion": "4.0.491",
+        "semver": "7.5.3",
+        "zod": "4.3.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/studio-server": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-server/-/studio-server-4.0.491.tgz",
+      "integrity": "sha512-7VzujJeB2itZMU3IYK1hG+lmjIR0U/qP1404Hzatocfm30+she0prHxkuMKeNrOPjEKZ5jwZHVKfF5egWRgwxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "7.24.1",
+        "@babel/types": "7.24.0",
+        "@remotion/bundler": "4.0.491",
+        "@remotion/renderer": "4.0.491",
+        "@remotion/studio-shared": "4.0.491",
+        "memfs": "3.4.3",
+        "open": "8.4.2",
+        "prettier": "3.8.1",
+        "recast": "0.23.11",
+        "remotion": "4.0.491",
+        "semver": "7.5.3"
+      }
+    },
+    "node_modules/@remotion/studio-shared": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-shared/-/studio-shared-4.0.491.tgz",
+      "integrity": "sha512-Izo9rc5ydUx4fMazdBdJNyo0UEjAelxlH2WoKVrF1XKTpxENRa40Cf4RodsaeyKc1qAM530ADF1mnuYipVnPYg==",
+      "license": "MIT",
+      "dependencies": {
+        "remotion": "4.0.491"
+      }
+    },
+    "node_modules/@remotion/timeline-utils": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/timeline-utils/-/timeline-utils-4.0.491.tgz",
+      "integrity": "sha512-BvXOCut6xJEnVqd+kRgJfAhetspAsm9E1BMb1tZ7jYTGxoeqlYjcy04oZQq/rhHKDF0tTGovV34Ve/RsQJ698A==",
+      "license": "MIT",
+      "dependencies": {
+        "mediabunny": "1.50.8"
+      }
+    },
+    "node_modules/@remotion/web-renderer": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/web-renderer/-/web-renderer-4.0.491.tgz",
+      "integrity": "sha512-yRXyiTPRuh6b0IKOVHCHXyTLXoLqcO0ZN+h0BF5Xc9WyjuiaTKEM80Ld1mVRr3hKUR3/RaAasvSZzczUNlPdgg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@mediabunny/aac-encoder": "1.50.8",
+        "@mediabunny/flac-encoder": "1.50.8",
+        "@mediabunny/mp3-encoder": "1.50.8",
+        "@remotion/licensing": "4.0.491",
+        "mediabunny": "1.50.8",
+        "remotion": "4.0.491"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@remotion/zod-types": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/@remotion/zod-types/-/zod-types-4.0.491.tgz",
+      "integrity": "sha512-LiZQ5RsTRbcq7gwD2gP7YRPxEzgv0CQpO/4oC6w49t34Bt7iCMUvzT8m0ktPejCjTlPq3wAqGSrCI4DzQxYPJw==",
+      "license": "MIT",
+      "dependencies": {
+        "remotion": "4.0.491"
+      }
+    },
+    "node_modules/@rspack/binding": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.7.11.tgz",
+      "integrity": "sha512-2MGdy2s2HimsDT444Bp5XnALzNRxuBNc7y0JzyuqKbHBywd4x2NeXyhWXXoxufaCFu5PBc9Qq9jyfjW2Aeh06Q==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@rspack/binding-darwin-arm64": "1.7.11",
+        "@rspack/binding-darwin-x64": "1.7.11",
+        "@rspack/binding-linux-arm64-gnu": "1.7.11",
+        "@rspack/binding-linux-arm64-musl": "1.7.11",
+        "@rspack/binding-linux-x64-gnu": "1.7.11",
+        "@rspack/binding-linux-x64-musl": "1.7.11",
+        "@rspack/binding-wasm32-wasi": "1.7.11",
+        "@rspack/binding-win32-arm64-msvc": "1.7.11",
+        "@rspack/binding-win32-ia32-msvc": "1.7.11",
+        "@rspack/binding-win32-x64-msvc": "1.7.11"
+      }
+    },
+    "node_modules/@rspack/binding-darwin-arm64": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.7.11.tgz",
+      "integrity": "sha512-oduECiZVqbO5zlVw+q7Vy65sJFth99fWPTyucwvLJJtJkPL5n17Uiql2cYP6Ijn0pkqtf1SXgK8WjiKLG5bIig==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rspack/binding-darwin-x64": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.7.11.tgz",
+      "integrity": "sha512-a1+TtTE9ap6RalgFi7FGIgkJP6O4Vy6ctv+9WGJy53E4kuqHR0RygzaiVxCI/GMc/vBT9vY23hyrpWb3d1vtXA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-arm64-gnu": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.7.11.tgz",
+      "integrity": "sha512-P0QrGRPbTWu6RKWfN0bDtbnEps3rXH0MWIMreZABoUrVmNQKtXR6e73J3ub6a+di5s2+K0M2LJ9Bh2/H4UsDUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-arm64-musl": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.7.11.tgz",
+      "integrity": "sha512-6ky7R43VMjWwmx3Yx7Jl7faLBBMAgMDt+/bN35RgwjiPgsIByz65EwytUVuW9rikB43BGHvA/eqlnjLrUzNBqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-x64-gnu": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.7.11.tgz",
+      "integrity": "sha512-cuOJMfCOvb2Wgsry5enXJ3iT1FGUjdPqtGUBVupQlEG4ntSYsQ2PtF4wIDVasR3wdxC5nQbipOrDiN/u6fYsdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-x64-musl": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.7.11.tgz",
+      "integrity": "sha512-CoK37hva4AmHGh3VCsQXmGr40L36m1/AdnN5LEjUX6kx5rEH7/1nEBN6Ii72pejqDVvk9anEROmPDiPw10tpFg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-wasm32-wasi": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.7.11.tgz",
+      "integrity": "sha512-OtrmnPUVJMxjNa3eDMfHyPdtlLRmmp/aIm0fQHlAOATbZvlGm12q7rhPW5BXTu1yh+1rQ1/uqvz+SzKEZXuJaQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "1.0.7"
+      }
+    },
+    "node_modules/@rspack/binding-win32-arm64-msvc": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.7.11.tgz",
+      "integrity": "sha512-lObFW6e5lCWNgTBNwT//yiEDbsxm9QG4BYUojqeXxothuzJ/L6ibXz6+gLMvbOvLGV3nKgkXmx8GvT9WDKR0mA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/binding-win32-ia32-msvc": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.7.11.tgz",
+      "integrity": "sha512-0pYGnZd8PPqNR68zQ8skamqNAXEA1sUfXuAdYcknIIRq2wsbiwFzIc0Pov1cIfHYab37G7sSIPBiOUdOWF5Ivw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/binding-win32-x64-msvc": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.7.11.tgz",
+      "integrity": "sha512-EeQXayoQk/uBkI3pdoXfQBXNIUrADq56L3s/DFyM2pJeUDrWmhfIw2UFIGkYPTMSCo8F2JcdcGM32FGJrSnU0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/core": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.7.11.tgz",
+      "integrity": "sha512-rsD9b+Khmot5DwCMiB3cqTQo53ioPG3M/A7BySu8+0+RS7GCxKm+Z+mtsjtG/vsu4Tn2tcqCdZtA3pgLoJB+ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime-tools": "0.22.0",
+        "@rspack/binding": "1.7.11",
+        "@rspack/lite-tapable": "1.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.1"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rspack/lite-tapable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.1.0.tgz",
+      "integrity": "sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==",
+      "license": "MIT"
+    },
+    "node_modules/@rspack/plugin-react-refresh": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@rspack/plugin-react-refresh/-/plugin-react-refresh-1.6.1.tgz",
+      "integrity": "sha512-eqqW5645VG3CzGzFgNg5HqNdHVXY+567PGjtDhhrM8t67caxmsSzRmT5qfoEIfBcGgFkH9vEg7kzXwmCYQdQDw==",
+      "license": "MIT",
+      "dependencies": {
+        "error-stack-parser": "^2.1.4",
+        "html-entities": "^2.6.0"
+      },
+      "peerDependencies": {
+        "react-refresh": ">=0.10.0 <1.0.0",
+        "webpack-hot-middleware": "2.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-hot-middleware": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/dom-mediacapture-transform": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.12.tgz",
+      "integrity": "sha512-d7/QsLRwF864A5mgIM/YrfiglHoYn7zgCcAoJgW404r+2DwnNr7EBbLnCWpmOMgH8y0te73L1AV6H1bmauaWFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "*"
+      }
+    },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
+      "integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-loader": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.4.tgz",
+      "integrity": "sha512-vv3J9tlOl04WjiMvHQI/9tmIrCxVrj6PFbHemBB1iihpeRbi/I4h033eoFIhwxBBqLhI0KYFS7yvynBFhIZfTw==",
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.1.0",
+        "postcss": "^8.4.40",
+        "postcss-modules-extract-imports": "^3.1.0",
+        "postcss-modules-local-by-default": "^4.0.5",
+        "postcss-modules-scope": "^3.2.0",
+        "postcss-modules-values": "^4.0.0",
+        "postcss-value-parser": "^4.2.0",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
+        "webpack": "^5.27.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/css-loader/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
+      "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fs-monkey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
+      "integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==",
+      "license": "Unlicense"
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loader-runner": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mediabunny": {
+      "version": "1.50.8",
+      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.50.8.tgz",
+      "integrity": "sha512-LgykLyQzhdpo0V2yw3UXmOpj+b4JAGdpHBwsPE6kjSt8Za0d1VllD+FV7EGHBcdV4+oHUAo+yrqbVAWxNSDCPQ==",
+      "license": "MPL-2.0",
+      "workspaces": [
+        ".",
+        "packages/*"
+      ],
+      "dependencies": {
+        "@types/dom-mediacapture-transform": "^0.1.11",
+        "@types/dom-webcodecs": "0.1.13"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      }
+    },
+    "node_modules/memfs": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.3.tgz",
+      "integrity": "sha512-eivjfi7Ahr6eQTn44nvTnR60e4a1Fs1Via2kCR5lHo/kyNoiMWaXCNJ/GpSd0ilXas2JSOl9B5FTIhflXu0hlg==",
+      "license": "Unlicense",
+      "dependencies": {
+        "fs-monkey": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-modules-extract-imports": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
+      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-local-by-default": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
+      "integrity": "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==",
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^7.0.0",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-scope": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
+      "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "license": "ISC",
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recast": {
+      "version": "0.23.11",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
+      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recast/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/remotion": {
+      "version": "4.0.491",
+      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.491.tgz",
+      "integrity": "sha512-17Y4QpoYvdkToWEimCcz44ydNeXjUGc25j0hXn0aKxgkBkZsa00s9D3q7/t/TW1vrQ7QIZCz2kVkXHB/5XHpXA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "deprecated": "The work that was done in this beta branch won't be included in future versions",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "whatwg-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/style-loader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
+      "integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.27.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/watchpack": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/webpack": {
+      "version": "5.105.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
+      "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.15.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.19.0",
+        "es-module-lexer": "^2.0.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.3.1",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.16",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+      "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/tools/promo/package.json
+++ b/tools/promo/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "motiq-promo-videos",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Internal marketing tool: renders Motiq promo GIFs with Remotion. Not part of the product packages.",
+  "scripts": {
+    "studio": "remotion studio src/index.ts",
+    "render": "node scripts/render-gifs.mjs",
+    "render:social": "node scripts/render-social.mjs",
+    "test:determinism": "node scripts/determinism-test.mjs"
+  },
+  "dependencies": {
+    "@remotion/cli": "4.0.491",
+    "@remotion/google-fonts": "4.0.491",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "remotion": "4.0.491",
+    "zod": "4.3.6"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/tools/promo/remotion.config.ts
+++ b/tools/promo/remotion.config.ts
@@ -1,0 +1,4 @@
+import { Config } from "@remotion/cli/config";
+
+Config.setVideoImageFormat("png");
+Config.setOverwriteOutput(true);

--- a/tools/promo/scripts/determinism-test.mjs
+++ b/tools/promo/scripts/determinism-test.mjs
@@ -1,0 +1,42 @@
+// Deterministic-frame test: renders the same mid-composition frame twice per
+// composition and asserts identical pixel hashes (same props -> same frames).
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const toolDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const tmp = join(toolDir, "out", "determinism");
+rmSync(tmp, { recursive: true, force: true });
+mkdirSync(tmp, { recursive: true });
+
+const cases = [
+  ["motiq-intro", 90],
+  ["motiq-install", 200],
+  ["motiq-showcase", 120],
+  ["motiq-pillars", 100],
+  ["motiq-free", 110],
+  ["motiq-cat-product-backgrounds", 130],
+  ["motiq-cat-ai", 130],
+  ["motiq-cat-commerce", 130],
+];
+
+let failed = false;
+for (const [id, frame] of cases) {
+  const hashes = [];
+  for (const run of [1, 2]) {
+    const png = join(tmp, `${id}-${run}.png`);
+    execFileSync(
+      "npx",
+      ["remotion", "still", "src/index.ts", id, png, `--frame=${frame}`, "--log=error"],
+      { cwd: toolDir, stdio: "inherit" },
+    );
+    hashes.push(createHash("sha256").update(readFileSync(png)).digest("hex"));
+  }
+  const ok = hashes[0] === hashes[1];
+  if (!ok) failed = true;
+  console.log(`${ok ? "✔" : "✘"} ${id} frame ${frame}: ${ok ? "deterministic" : "HASH MISMATCH"}`);
+}
+
+process.exit(failed ? 1 : 0);

--- a/tools/promo/scripts/render-gifs.mjs
+++ b/tools/promo/scripts/render-gifs.mjs
@@ -1,0 +1,64 @@
+// Renders every promo composition to MP4, then converts to a looping GIF via
+// ffmpeg's two-pass palette pipeline (much better color than a direct GIF encode).
+// Output: assets/promo/<id>.gif at the repo root.
+import { execFileSync } from "node:child_process";
+import { mkdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const toolDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolve(toolDir, "..", "..");
+const outDir = join(toolDir, "out");
+const gifDir = join(repoRoot, "assets", "promo");
+mkdirSync(outDir, { recursive: true });
+mkdirSync(gifDir, { recursive: true });
+
+const compositions = [
+  "motiq-intro",
+  "motiq-install",
+  "motiq-showcase",
+  "motiq-pillars",
+  "motiq-free",
+  "motiq-cat-product-backgrounds",
+  "motiq-cat-workflow-heroes",
+  "motiq-cat-ai",
+  "motiq-cat-developer-tools",
+  "motiq-cat-collaboration",
+  "motiq-cat-data-motion",
+  "motiq-cat-productivity",
+  "motiq-cat-file-workflows",
+  "motiq-cat-commerce",
+  "motiq-cat-security",
+  "motiq-cat-communication",
+];
+
+const only = process.argv.slice(2);
+const targets = only.length > 0 ? compositions.filter((c) => only.includes(c)) : compositions;
+
+for (const id of targets) {
+  const mp4 = join(outDir, `${id}.mp4`);
+  const gif = join(gifDir, `${id}.gif`);
+
+  console.log(`\n▶ Rendering ${id} …`);
+  execFileSync(
+    "npx",
+    ["remotion", "render", "src/index.ts", id, mp4, "--codec=h264", "--crf=15", "--log=error"],
+    { cwd: toolDir, stdio: "inherit" },
+  );
+
+  console.log(`▶ Encoding GIF ${id} …`);
+  const filter =
+    "fps=20,scale=960:-1:flags=lanczos,split[s0][s1];" +
+    "[s0]palettegen=max_colors=220:stats_mode=diff[p];" +
+    "[s1][p]paletteuse=dither=sierra2_4a:diff_mode=rectangle";
+  execFileSync(
+    "ffmpeg",
+    ["-y", "-loglevel", "error", "-i", mp4, "-vf", filter, "-loop", "0", gif],
+    { stdio: "inherit" },
+  );
+
+  const mb = (statSync(gif).size / 1024 / 1024).toFixed(2);
+  console.log(`✔ ${gif} (${mb} MB)`);
+}
+
+console.log("\nAll GIFs written to assets/promo/");

--- a/tools/promo/scripts/render-social.mjs
+++ b/tools/promo/scripts/render-social.mjs
@@ -1,0 +1,63 @@
+// Renders the social promotion kit to assets/promo/:
+//   motiq-trailer.mp4   16:9 1280x720  ~32s  (X/LinkedIn native video upload)
+//   motiq-square.mp4/.gif  1:1 1080x1080 12s loop (feeds)
+//   motiq-vertical.mp4  9:16 1080x1920 12s (Shorts/Reels/TikTok)
+//   motiq-card.png      1200x675 static (X image posts / link cards)
+import { execFileSync } from "node:child_process";
+import { mkdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const toolDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolve(toolDir, "..", "..");
+const outDir = join(repoRoot, "assets", "promo");
+mkdirSync(outDir, { recursive: true });
+
+const render = (id, out, extra = []) =>
+  execFileSync(
+    "npx",
+    ["remotion", "render", "src/index.ts", id, out, "--codec=h264", "--crf=17", "--log=error", ...extra],
+    { cwd: toolDir, stdio: "inherit" },
+  );
+
+const report = (file) =>
+  console.log(`✔ ${file} (${(statSync(file).size / 1024 / 1024).toFixed(2)} MB)`);
+
+console.log("▶ Rendering trailer …");
+const trailer = join(outDir, "motiq-trailer.mp4");
+render("motiq-trailer", trailer);
+report(trailer);
+
+console.log("▶ Rendering square loop …");
+const squareMp4 = join(outDir, "motiq-square.mp4");
+render("motiq-square", squareMp4);
+report(squareMp4);
+
+const squareGif = join(outDir, "motiq-square.gif");
+execFileSync(
+  "ffmpeg",
+  [
+    "-y", "-loglevel", "error", "-i", squareMp4,
+    "-vf",
+    "fps=20,scale=720:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=220:stats_mode=diff[p];[s1][p]paletteuse=dither=sierra2_4a:diff_mode=rectangle",
+    "-loop", "0", squareGif,
+  ],
+  { stdio: "inherit" },
+);
+report(squareGif);
+
+console.log("▶ Rendering vertical …");
+const vertical = join(outDir, "motiq-vertical.mp4");
+render("motiq-vertical", vertical);
+report(vertical);
+
+console.log("▶ Rendering static card …");
+const card = join(outDir, "motiq-card.png");
+execFileSync(
+  "npx",
+  ["remotion", "still", "src/index.ts", "motiq-card", card, "--frame=150", "--log=error"],
+  { cwd: toolDir, stdio: "inherit" },
+);
+report(card);
+
+console.log("\nSocial kit written to assets/promo/");

--- a/tools/promo/src/Root.tsx
+++ b/tools/promo/src/Root.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { Composition } from "remotion";
+import { loadFont as loadInter } from "@remotion/google-fonts/Inter";
+import { loadFont as loadMono } from "@remotion/google-fonts/JetBrainsMono";
+import { Intro, introDefaults, introSchema } from "./comps/Intro";
+import { Install, installDefaults, installSchema } from "./comps/Install";
+import { Showcase, showcaseDefaults, showcaseSchema } from "./comps/Showcase";
+import { Pillars, pillarsDefaults, pillarsSchema } from "./comps/Pillars";
+import { OpenSource, openSourceDefaults, openSourceSchema } from "./comps/OpenSource";
+import { categories } from "./comps/category";
+import { categorySchema } from "./comps/category/Layout";
+import { Trailer, TRAILER_DURATION, trailerDefaults, trailerSchema } from "./comps/social/Trailer";
+import { SquareLoop, squareDefaults, squareSchema } from "./comps/social/SquareLoop";
+import { Vertical, verticalDefaults, verticalSchema } from "./comps/social/Vertical";
+import { StaticCard, cardDefaults, cardSchema } from "./comps/social/StaticCard";
+
+loadInter("normal", { weights: ["500", "600", "700", "800"], subsets: ["latin"] });
+loadMono("normal", { weights: ["500", "700"], subsets: ["latin"] });
+
+const base = { width: 1200, height: 675, fps: 30 } as const;
+
+export const Root: React.FC = () => (
+  <>
+    <Composition
+      id="motiq-intro"
+      component={Intro}
+      schema={introSchema}
+      defaultProps={introDefaults}
+      durationInFrames={180}
+      {...base}
+    />
+    <Composition
+      id="motiq-install"
+      component={Install}
+      schema={installSchema}
+      defaultProps={installDefaults}
+      durationInFrames={240}
+      {...base}
+    />
+    <Composition
+      id="motiq-showcase"
+      component={Showcase}
+      schema={showcaseSchema}
+      defaultProps={showcaseDefaults}
+      durationInFrames={240}
+      {...base}
+    />
+    <Composition
+      id="motiq-pillars"
+      component={Pillars}
+      schema={pillarsSchema}
+      defaultProps={pillarsDefaults}
+      durationInFrames={210}
+      {...base}
+    />
+    <Composition
+      id="motiq-free"
+      component={OpenSource}
+      schema={openSourceSchema}
+      defaultProps={openSourceDefaults}
+      durationInFrames={195}
+      {...base}
+    />
+    {categories.map((cat) => (
+      <Composition
+        key={cat.id}
+        id={cat.id}
+        component={cat.component}
+        schema={categorySchema}
+        defaultProps={cat.defaults}
+        durationInFrames={240}
+        {...base}
+      />
+    ))}
+    <Composition
+      id="motiq-trailer"
+      component={Trailer}
+      schema={trailerSchema}
+      defaultProps={trailerDefaults}
+      durationInFrames={TRAILER_DURATION}
+      width={1280}
+      height={720}
+      fps={30}
+    />
+    <Composition
+      id="motiq-square"
+      component={SquareLoop}
+      schema={squareSchema}
+      defaultProps={squareDefaults}
+      durationInFrames={360}
+      width={1080}
+      height={1080}
+      fps={30}
+    />
+    <Composition
+      id="motiq-vertical"
+      component={Vertical}
+      schema={verticalSchema}
+      defaultProps={verticalDefaults}
+      durationInFrames={360}
+      width={1080}
+      height={1920}
+      fps={30}
+    />
+    <Composition
+      id="motiq-card"
+      component={StaticCard}
+      schema={cardSchema}
+      defaultProps={cardDefaults}
+      durationInFrames={200}
+      {...base}
+    />
+  </>
+);

--- a/tools/promo/src/comps/Install.tsx
+++ b/tools/promo/src/comps/Install.tsx
@@ -1,0 +1,186 @@
+import React from "react";
+import { AbsoluteFill, interpolate, useCurrentFrame, useVideoConfig } from "remotion";
+import { z } from "zod";
+import { enter, fade, pop } from "../helpers";
+import { colors, monoFamily } from "../theme";
+import { Stage, Window } from "../shared";
+
+export const installSchema = z.object({
+  command: z.string(),
+  componentName: z.string(),
+});
+
+export const installDefaults: z.infer<typeof installSchema> = {
+  command: "npx shadcn add https://motiq.dev/r/spotlight-card",
+  componentName: "spotlight-card",
+};
+
+const TYPE_START = 14;
+const CHARS_PER_FRAME = 0.62;
+const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧"];
+
+export const Install: React.FC<z.infer<typeof installSchema>> = ({ command, componentName }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  const typedCount = Math.min(
+    command.length,
+    Math.max(0, Math.floor((frame - TYPE_START) * CHARS_PER_FRAME)),
+  );
+  const typeEnd = TYPE_START + command.length / CHARS_PER_FRAME;
+  const enterPressed = frame > typeEnd + 8;
+  const cursorOn = Math.floor(frame / 16) % 2 === 0;
+
+  const steps = [
+    { at: typeEnd + 14, text: "Checking registry." },
+    { at: typeEnd + 30, text: "Installing dependencies." },
+    { at: typeEnd + 46, text: `Created components/ui/${componentName}.tsx` },
+  ];
+  const doneAt = steps[2].at + 6;
+  const cardIn = pop({ frame, fps, delay: doneAt });
+
+  // Spotlight orbit inside the preview card once it lands.
+  const t = Math.max(0, frame - doneAt) / fps;
+  const spotX = 50 + Math.cos(t * 1.4) * 32;
+  const spotY = 45 + Math.sin(t * 1.4) * 26;
+
+  const windowIn = enter({ frame, fps, delay: 0 });
+
+  return (
+    <Stage glowX="28%" glowY="24%">
+      <AbsoluteFill
+        style={{ flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 40 }}
+      >
+        <div
+          style={{
+            opacity: windowIn,
+            transform: `translateY(${interpolate(windowIn, [0, 1], [30, 0])}px)`,
+          }}
+        >
+          <Window title="motiq — zsh" width={694}>
+            <div
+              style={{
+                padding: "26px 28px",
+                fontFamily: monoFamily,
+                fontSize: 19,
+                lineHeight: 1.9,
+                minHeight: 300,
+                color: colors.fgSecondary,
+              }}
+            >
+              <div style={{ display: "flex", flexWrap: "wrap" }}>
+                <span style={{ color: colors.success, marginRight: 12 }}>❯</span>
+                <span style={{ color: colors.fg, wordBreak: "break-all", flex: 1 }}>
+                  {command.slice(0, typedCount)}
+                  {!enterPressed && (
+                    <span
+                      style={{
+                        display: "inline-block",
+                        width: 11,
+                        height: 22,
+                        marginLeft: 2,
+                        verticalAlign: "text-bottom",
+                        background: cursorOn ? colors.accentText : "transparent",
+                      }}
+                    />
+                  )}
+                </span>
+              </div>
+              {enterPressed && frame < steps[0].at && (
+                <div style={{ color: colors.accentText }}>
+                  {SPINNER[Math.floor(frame / 4) % SPINNER.length]} Resolving {componentName}…
+                </div>
+              )}
+              {steps.map((step) => {
+                const o = fade(frame, step.at, step.at + 6);
+                return (
+                  <div key={step.text} style={{ opacity: o }}>
+                    <span style={{ color: colors.success, marginRight: 10 }}>✔</span>
+                    {step.text}
+                  </div>
+                );
+              })}
+              <div style={{ opacity: fade(frame, doneAt + 4, doneAt + 10), color: colors.muted }}>
+                <span style={{ color: colors.success, marginRight: 10 }}>❯</span>
+                Done. Editable source — it&apos;s yours now.
+              </div>
+            </div>
+          </Window>
+        </div>
+
+        <div
+          style={{
+            width: 360,
+            opacity: cardIn,
+            transform: `scale(${interpolate(cardIn, [0, 1], [0.8, 1])}) translateY(${interpolate(cardIn, [0, 1], [24, 0])}px)`,
+          }}
+        >
+          <div
+            style={{
+              position: "relative",
+              borderRadius: 20,
+              border: `1px solid ${colors.borderStrong}`,
+              background: colors.surface,
+              padding: 30,
+              overflow: "hidden",
+              boxShadow: `0 30px 80px rgba(0,0,0,0.5), 0 0 60px rgba(79,124,255,0.18)`,
+            }}
+          >
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                background: `radial-gradient(circle 220px at ${spotX}% ${spotY}%, rgba(79,124,255,0.28), transparent 70%)`,
+              }}
+            />
+            <div style={{ position: "relative" }}>
+              <div
+                style={{
+                  width: 52,
+                  height: 52,
+                  borderRadius: 14,
+                  background: colors.accentSoft,
+                  border: `1px solid ${colors.borderStrong}`,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  marginBottom: 20,
+                }}
+              >
+                <svg width={26} height={26} viewBox="0 0 24 24" fill="none">
+                  <path
+                    d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M5.6 18.4l2.1-2.1M16.3 7.7l2.1-2.1"
+                    stroke={colors.accentText}
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </div>
+              <div style={{ fontSize: 26, fontWeight: 700, color: colors.fg, marginBottom: 10 }}>
+                Spotlight Card
+              </div>
+              <div style={{ fontSize: 18, lineHeight: 1.6, color: colors.muted }}>
+                A pointer-tracking glow that lifts your content off the page.
+              </div>
+              <div
+                style={{
+                  marginTop: 22,
+                  display: "inline-flex",
+                  padding: "10px 20px",
+                  borderRadius: 10,
+                  background: colors.accent,
+                  color: "#fff",
+                  fontSize: 17,
+                  fontWeight: 600,
+                  boxShadow: "0 8px 24px rgba(79,124,255,0.4)",
+                }}
+              >
+                Ship it
+              </div>
+            </div>
+          </div>
+        </div>
+      </AbsoluteFill>
+    </Stage>
+  );
+};

--- a/tools/promo/src/comps/Intro.tsx
+++ b/tools/promo/src/comps/Intro.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { AbsoluteFill, interpolate, useCurrentFrame, useVideoConfig } from "remotion";
+import { z } from "zod";
+import { enter, pop } from "../helpers";
+import { brand, colors, monoFamily } from "../theme";
+import { Badge, Logomark, Stage } from "../shared";
+
+export const introSchema = z.object({
+  title: z.string(),
+  tagline: z.string(),
+  kicker: z.string(),
+});
+
+export const introDefaults: z.infer<typeof introSchema> = {
+  title: brand.name,
+  tagline: brand.tagline,
+  kicker: "Animated component library",
+};
+
+export const Intro: React.FC<z.infer<typeof introSchema>> = ({ title, tagline, kicker }) => {
+  const frame = useCurrentFrame();
+  const { fps, width } = useVideoConfig();
+  const letters = title.split("");
+
+  const markIn = pop({ frame, fps, delay: 4 });
+  const taglineIn = enter({ frame, fps, delay: 36 });
+  const pillIn = enter({ frame, fps, delay: 52 });
+  // Shine sweep across the wordmark once the letters have landed.
+  const shineX = interpolate(frame, [40, 85], [-30, 130], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  });
+
+  return (
+    <Stage glowY="30%">
+      <AbsoluteFill
+        style={{
+          alignItems: "center",
+          justifyContent: "center",
+          flexDirection: "column",
+          gap: 34,
+        }}
+      >
+        <Badge delay={0}>{kicker}</Badge>
+
+        <div style={{ display: "flex", alignItems: "center", gap: 30 }}>
+          <div style={{ transform: `scale(${markIn}) rotate(${interpolate(markIn, [0, 1], [-14, 0])}deg)` }}>
+            <Logomark size={96} />
+          </div>
+          <div style={{ position: "relative", display: "flex" }}>
+            {letters.map((letter, i) => {
+              const p = enter({ frame, fps, delay: 10 + i * 3.5 });
+              return (
+                <span
+                  key={i}
+                  style={{
+                    fontSize: 132,
+                    fontWeight: 800,
+                    letterSpacing: -4,
+                    color: colors.fg,
+                    display: "inline-block",
+                    opacity: p,
+                    transform: `translateY(${interpolate(p, [0, 1], [46, 0])}px)`,
+                  }}
+                >
+                  {letter}
+                </span>
+              );
+            })}
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                background: `linear-gradient(105deg, transparent ${shineX - 18}%, rgba(127,159,255,0.5) ${shineX}%, transparent ${shineX + 18}%)`,
+                mixBlendMode: "screen",
+                pointerEvents: "none",
+              }}
+            />
+          </div>
+        </div>
+
+        <div
+          style={{
+            maxWidth: width * 0.62,
+            textAlign: "center",
+            fontSize: 30,
+            lineHeight: 1.45,
+            fontWeight: 500,
+            color: colors.fgSecondary,
+            opacity: taglineIn,
+            transform: `translateY(${interpolate(taglineIn, [0, 1], [18, 0])}px)`,
+          }}
+        >
+          {tagline}
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "12px 24px",
+            borderRadius: 12,
+            border: `1px solid ${colors.borderStrong}`,
+            background: colors.surface,
+            fontFamily: monoFamily,
+            fontSize: 21,
+            color: colors.accentText,
+            opacity: pillIn,
+            transform: `translateY(${interpolate(pillIn, [0, 1], [16, 0])}px)`,
+            boxShadow: "0 12px 40px rgba(0,0,0,0.4)",
+          }}
+        >
+          <span style={{ color: colors.success }}>▲</span>
+          {brand.domain}
+        </div>
+      </AbsoluteFill>
+    </Stage>
+  );
+};

--- a/tools/promo/src/comps/OpenSource.tsx
+++ b/tools/promo/src/comps/OpenSource.tsx
@@ -1,0 +1,169 @@
+import React from "react";
+import { AbsoluteFill, interpolate, useCurrentFrame, useVideoConfig } from "remotion";
+import { z } from "zod";
+import { enter, pop, seededRandom } from "../helpers";
+import { brand, colors, monoFamily } from "../theme";
+import { Badge, Logomark, Stage } from "../shared";
+
+export const openSourceSchema = z.object({
+  heading: z.string(),
+  kicker: z.string(),
+  particleSeed: z.number().int(),
+});
+
+export const openSourceDefaults: z.infer<typeof openSourceSchema> = {
+  heading: "Free & open source",
+  kicker: "Every component. Every block. No paywall.",
+  particleSeed: 7,
+};
+
+const Particles: React.FC<{ seed: number }> = ({ seed }) => {
+  const frame = useCurrentFrame();
+  const { width, height, durationInFrames } = useVideoConfig();
+  const rand = seededRandom(seed);
+  const particles = Array.from({ length: 26 }, () => ({
+    x: rand() * width,
+    y: rand() * height,
+    size: 2 + rand() * 3.5,
+    speed: 0.25 + rand() * 0.5,
+    phase: rand() * Math.PI * 2,
+  }));
+  return (
+    <AbsoluteFill>
+      {particles.map((p, i) => {
+        const y = (((p.y - frame * p.speed) % height) + height) % height;
+        const cyclesForLoop = Math.max(1, Math.round(durationInFrames / 60));
+        const twinkle =
+          0.25 + 0.6 * (0.5 + 0.5 * Math.sin(p.phase + (frame / durationInFrames) * Math.PI * 2 * cyclesForLoop));
+        return (
+          <div
+            key={i}
+            style={{
+              position: "absolute",
+              left: p.x,
+              top: y,
+              width: p.size,
+              height: p.size,
+              borderRadius: 999,
+              background: colors.accentText,
+              opacity: twinkle,
+              boxShadow: `0 0 ${p.size * 3}px rgba(127,159,255,0.6)`,
+            }}
+          />
+        );
+      })}
+    </AbsoluteFill>
+  );
+};
+
+export const OpenSource: React.FC<z.infer<typeof openSourceSchema>> = ({
+  heading,
+  kicker,
+  particleSeed,
+}) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const markIn = pop({ frame, fps, delay: 2 });
+  const headIn = enter({ frame, fps, delay: 12 });
+  const starIn = pop({ frame, fps, delay: 40 });
+  const cmdIn = enter({ frame, fps, delay: 54 });
+  const starPulse = 1 + Math.sin((frame / 40) * Math.PI * 2) * 0.03;
+  const starSpin = interpolate(frame, [40, 70], [-180, 0], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  });
+
+  return (
+    <Stage glowY="26%">
+      <Particles seed={particleSeed} />
+      <AbsoluteFill
+        style={{ alignItems: "center", justifyContent: "center", flexDirection: "column", gap: 30 }}
+      >
+        <div style={{ transform: `scale(${markIn})` }}>
+          <Logomark size={84} />
+        </div>
+        <div style={{ textAlign: "center" }}>
+          <div
+            style={{
+              fontSize: 84,
+              fontWeight: 800,
+              letterSpacing: -3,
+              lineHeight: 1.08,
+              opacity: headIn,
+              transform: `translateY(${interpolate(headIn, [0, 1], [30, 0])}px)`,
+              background: `linear-gradient(110deg, ${colors.fg} 20%, ${colors.accentText} 55%, ${colors.fg} 85%)`,
+              WebkitBackgroundClip: "text",
+              backgroundClip: "text",
+              color: "transparent",
+            }}
+          >
+            {heading}
+          </div>
+          <div style={{ marginTop: 16, opacity: headIn }}>
+            <Badge delay={16}>{kicker}</Badge>
+          </div>
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 12,
+              padding: "14px 26px",
+              borderRadius: 12,
+              background: colors.fg,
+              color: "#0b1020",
+              fontSize: 21,
+              fontWeight: 700,
+              transform: `scale(${Math.min(1, starIn) * starPulse})`,
+              boxShadow: "0 14px 40px rgba(248,250,252,0.18)",
+            }}
+          >
+            <svg
+              width={22}
+              height={22}
+              viewBox="0 0 24 24"
+              fill="#0b1020"
+              style={{ transform: `rotate(${starSpin}deg)` }}
+            >
+              <path d="M12 1.75l3.1 6.3 6.9 1-5 4.9 1.2 6.9-6.2-3.3-6.2 3.3 1.2-6.9-5-4.9 6.9-1z" />
+            </svg>
+            Star on GitHub
+          </div>
+          <div
+            style={{
+              padding: "14px 24px",
+              borderRadius: 12,
+              border: `1px solid ${colors.borderStrong}`,
+              background: colors.surface,
+              fontFamily: monoFamily,
+              fontSize: 19,
+              color: colors.fgSecondary,
+              opacity: cmdIn,
+              transform: `translateY(${interpolate(cmdIn, [0, 1], [14, 0])}px)`,
+            }}
+          >
+            <span style={{ color: colors.success }}>❯ </span>
+            npx shadcn add {brand.domain}/r/…
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            gap: 26,
+            fontSize: 19,
+            fontWeight: 600,
+            color: colors.muted,
+            opacity: cmdIn,
+          }}
+        >
+          <span style={{ color: colors.accentText }}>{brand.domain}</span>
+          <span>·</span>
+          <span>{brand.github}</span>
+        </div>
+      </AbsoluteFill>
+    </Stage>
+  );
+};

--- a/tools/promo/src/comps/Pillars.tsx
+++ b/tools/promo/src/comps/Pillars.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { AbsoluteFill, interpolate, useCurrentFrame, useVideoConfig } from "remotion";
+import { z } from "zod";
+import { enter, pop } from "../helpers";
+import { colors } from "../theme";
+import { Badge, Stage } from "../shared";
+
+export const pillarsSchema = z.object({
+  heading: z.string(),
+  kicker: z.string(),
+  items: z.array(z.object({ title: z.string(), sub: z.string() })).length(4),
+});
+
+export const pillarsDefaults: z.infer<typeof pillarsSchema> = {
+  heading: "Production-ready by default",
+  kicker: "No cleanup required",
+  items: [
+    { title: "Accessible", sub: "WCAG 2.2 AA — keyboard, focus & screen readers covered." },
+    { title: "Reduced-motion safe", sub: "Every animation respects prefers-reduced-motion." },
+    { title: "SSR & RSC safe", sub: "No hydration surprises in Next.js App Router." },
+    { title: "Editable source", sub: "Installed into your repo. No lock-in, no black box." },
+  ],
+};
+
+const Check: React.FC<{ progress: number }> = ({ progress }) => {
+  const length = 26;
+  return (
+    <div
+      style={{
+        width: 54,
+        height: 54,
+        borderRadius: 999,
+        background: `linear-gradient(135deg, ${colors.accent}, #315fea)`,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        boxShadow: `0 0 ${24 * progress}px rgba(79,124,255,0.55)`,
+        flexShrink: 0,
+      }}
+    >
+      <svg width={26} height={26} viewBox="0 0 24 24" fill="none">
+        <path
+          d="M4.5 12.5l5 5L19.5 7"
+          stroke="#fff"
+          strokeWidth={3}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeDasharray={length}
+          strokeDashoffset={length * (1 - progress)}
+        />
+      </svg>
+    </div>
+  );
+};
+
+export const Pillars: React.FC<z.infer<typeof pillarsSchema>> = ({ heading, kicker, items }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const headIn = enter({ frame, fps, delay: 4 });
+  return (
+    <Stage glowY="16%">
+      <AbsoluteFill style={{ alignItems: "center", paddingTop: 62 }}>
+        <Badge delay={0}>{kicker}</Badge>
+        <div
+          style={{
+            marginTop: 20,
+            marginBottom: 40,
+            fontSize: 56,
+            fontWeight: 800,
+            letterSpacing: -1.5,
+            color: colors.fg,
+            opacity: headIn,
+            transform: `translateY(${interpolate(headIn, [0, 1], [22, 0])}px)`,
+          }}
+        >
+          {heading}
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 500px)", gap: 22 }}>
+          {items.map((item, i) => {
+            const delay = 22 + i * 14;
+            const p = enter({ frame, fps, delay });
+            const check = pop({ frame, fps, delay: delay + 8 });
+            return (
+              <div
+                key={item.title}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 22,
+                  padding: "26px 28px",
+                  borderRadius: 18,
+                  border: `1px solid ${colors.border}`,
+                  background: colors.surface,
+                  boxShadow: "0 16px 44px rgba(0,0,0,0.35)",
+                  opacity: p,
+                  transform: `translateX(${interpolate(p, [0, 1], [i % 2 === 0 ? -36 : 36, 0])}px)`,
+                }}
+              >
+                <div style={{ transform: `scale(${0.5 + Math.min(1, check) * 0.5})` }}>
+                  <Check progress={Math.min(1, Math.max(0, check))} />
+                </div>
+                <div>
+                  <div style={{ fontSize: 27, fontWeight: 700, color: colors.fg, marginBottom: 6 }}>
+                    {item.title}
+                  </div>
+                  <div style={{ fontSize: 18.5, lineHeight: 1.5, color: colors.muted }}>{item.sub}</div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </AbsoluteFill>
+    </Stage>
+  );
+};

--- a/tools/promo/src/comps/Showcase.tsx
+++ b/tools/promo/src/comps/Showcase.tsx
@@ -1,0 +1,378 @@
+import React from "react";
+import { AbsoluteFill, interpolate, spring, useCurrentFrame, useVideoConfig } from "remotion";
+import { z } from "zod";
+import { enter } from "../helpers";
+import { colors } from "../theme";
+import { Badge, Stage } from "../shared";
+
+export const showcaseSchema = z.object({
+  heading: z.string(),
+  kicker: z.string(),
+});
+
+export const showcaseDefaults: z.infer<typeof showcaseSchema> = {
+  heading: "60+ production-ready components & blocks",
+  kicker: "Explore the catalog",
+};
+
+const Tile: React.FC<{
+  label: string;
+  delay: number;
+  children: React.ReactNode;
+}> = ({ label, delay, children }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const p = enter({ frame, fps, delay });
+  return (
+    <div
+      style={{
+        width: 344,
+        height: 196,
+        borderRadius: 18,
+        border: `1px solid ${colors.border}`,
+        background: colors.surface,
+        boxShadow: "0 16px 44px rgba(0,0,0,0.4)",
+        overflow: "hidden",
+        position: "relative",
+        opacity: p,
+        transform: `translateY(${interpolate(p, [0, 1], [34, 0])}px) scale(${interpolate(p, [0, 1], [0.94, 1])})`,
+      }}
+    >
+      <div style={{ height: 148, display: "flex", alignItems: "center", justifyContent: "center" }}>
+        {children}
+      </div>
+      <div
+        style={{
+          position: "absolute",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          padding: "10px 18px",
+          fontSize: 15,
+          fontWeight: 600,
+          letterSpacing: 0.4,
+          color: colors.muted,
+          borderTop: `1px solid ${colors.border}`,
+          background: colors.bgElevated,
+        }}
+      >
+        {label}
+      </div>
+    </div>
+  );
+};
+
+/** Cycle helper: local frame within a repeating window, offset so tiles desync. */
+const cycle = (frame: number, period: number, offset = 0) => (frame + offset) % period;
+
+const ButtonsDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const local = cycle(frame, 75);
+  const press = spring({ frame: local - 30, fps, config: { damping: 14, stiffness: 300 }, durationInFrames: 20 });
+  const scale = 1 - Math.sin(Math.min(1, Math.max(0, press)) * Math.PI) * 0.08;
+  const ripple = interpolate(local, [34, 62], [0, 1], { extrapolateLeft: "clamp", extrapolateRight: "clamp" });
+  return (
+    <div style={{ position: "relative" }}>
+      <div
+        style={{
+          position: "absolute",
+          inset: -6,
+          borderRadius: 16,
+          border: `2px solid rgba(79,124,255,${0.5 * (1 - ripple)})`,
+          transform: `scale(${1 + ripple * 0.35})`,
+        }}
+      />
+      <div
+        style={{
+          padding: "14px 34px",
+          borderRadius: 12,
+          background: `linear-gradient(135deg, ${colors.accentHover}, #315fea)`,
+          color: "#fff",
+          fontSize: 20,
+          fontWeight: 700,
+          transform: `scale(${scale})`,
+          boxShadow: "0 10px 30px rgba(79,124,255,0.45)",
+        }}
+      >
+        Get started
+      </div>
+    </div>
+  );
+};
+
+export const ToggleDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const period = 70;
+  const phase = Math.floor(frame / period) % 2;
+  const local = frame % period;
+  const move = spring({ frame: local - 8, fps, config: { damping: 18, stiffness: 240 } });
+  const on = phase === 0 ? move : 1 - move;
+  return (
+    <div
+      style={{
+        width: 92,
+        height: 50,
+        borderRadius: 999,
+        padding: 5,
+        background: `color-mix(in srgb, ${colors.accent} ${on * 100}%, ${colors.surfaceStrong})`,
+        border: `1px solid ${colors.borderStrong}`,
+        boxShadow: on > 0.5 ? "0 0 26px rgba(79,124,255,0.5)" : "none",
+      }}
+    >
+      <div
+        style={{
+          width: 40,
+          height: 40,
+          borderRadius: 999,
+          background: "#fff",
+          transform: `translateX(${on * 42}px)`,
+          boxShadow: "0 3px 8px rgba(0,0,0,0.4)",
+        }}
+      />
+    </div>
+  );
+};
+
+export const ChartDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const bars = [0.45, 0.75, 0.55, 0.95, 0.65, 0.85];
+  return (
+    <div style={{ display: "flex", alignItems: "flex-end", gap: 14, height: 96 }}>
+      {bars.map((base, i) => {
+        const wave = Math.sin((frame / 30) * Math.PI * 0.5 + i * 0.9) * 0.14;
+        const h = Math.max(0.15, base + wave) * 96;
+        return (
+          <div
+            key={i}
+            style={{
+              width: 26,
+              height: h,
+              borderRadius: 7,
+              background:
+                i === 3
+                  ? `linear-gradient(180deg, ${colors.accentHover}, ${colors.accent})`
+                  : colors.surfaceStrong,
+              border: `1px solid ${i === 3 ? colors.accent : colors.borderStrong}`,
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export const KanbanDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const period = 110;
+  const phase = Math.floor(frame / period) % 2;
+  const local = frame % period;
+  const move = spring({ frame: local - 20, fps, config: { damping: 20, stiffness: 160 } });
+  const x = phase === 0 ? move : 1 - move;
+  const lift = Math.sin(Math.min(1, Math.max(0, x)) * Math.PI);
+  return (
+    <div style={{ display: "flex", gap: 16, position: "relative" }}>
+      {[0, 1].map((col) => (
+        <div
+          key={col}
+          style={{
+            width: 128,
+            height: 104,
+            borderRadius: 12,
+            border: `1px dashed ${colors.borderStrong}`,
+            background: colors.bgElevated,
+            padding: 8,
+          }}
+        >
+          <div style={{ fontSize: 12, fontWeight: 700, color: colors.muted, marginBottom: 6 }}>
+            {col === 0 ? "IN PROGRESS" : "DONE"}
+          </div>
+        </div>
+      ))}
+      <div
+        style={{
+          position: "absolute",
+          top: 30,
+          left: 8,
+          width: 112,
+          borderRadius: 9,
+          background: colors.surfaceRaised,
+          border: `1px solid ${colors.accent}`,
+          padding: "9px 10px",
+          transform: `translateX(${x * 144}px) translateY(${-lift * 12}px) rotate(${lift * 4}deg)`,
+          boxShadow: `0 ${6 + lift * 14}px ${16 + lift * 18}px rgba(0,0,0,0.45)`,
+        }}
+      >
+        <div style={{ width: 62, height: 8, borderRadius: 4, background: colors.accentText, opacity: 0.9 }} />
+        <div style={{ width: 84, height: 7, borderRadius: 4, background: colors.surfaceStrong, marginTop: 7 }} />
+      </div>
+    </div>
+  );
+};
+
+export const ComposerDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const dots = "Generating" + ".".repeat((Math.floor(frame / 14) % 3) + 1);
+  const glow = 0.35 + Math.sin((frame / 45) * Math.PI * 2) * 0.15;
+  return (
+    <div
+      style={{
+        width: 280,
+        borderRadius: 14,
+        border: `1px solid ${colors.borderStrong}`,
+        background: colors.bgElevated,
+        padding: 14,
+        boxShadow: `0 0 30px rgba(79,124,255,${glow * 0.4})`,
+      }}
+    >
+      <div style={{ fontSize: 16, color: colors.fgSecondary, marginBottom: 12 }}>
+        {dots}
+        <span
+          style={{
+            display: "inline-block",
+            width: 9,
+            height: 18,
+            marginLeft: 3,
+            verticalAlign: "text-bottom",
+            background: Math.floor(frame / 16) % 2 === 0 ? colors.accentText : "transparent",
+          }}
+        />
+      </div>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <div style={{ display: "flex", gap: 7 }}>
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              style={{
+                width: 26,
+                height: 26,
+                borderRadius: 8,
+                border: `1px solid ${colors.borderStrong}`,
+                background: colors.surface,
+              }}
+            />
+          ))}
+        </div>
+        <div
+          style={{
+            width: 34,
+            height: 34,
+            borderRadius: 10,
+            background: colors.accent,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            transform: `scale(${1 + glow * 0.12})`,
+          }}
+        >
+          <svg width={16} height={16} viewBox="0 0 24 24" fill="none">
+            <path d="M5 12h13M13 6l6 6-6 6" stroke="#fff" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const AvatarsDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const tints = ["#7f9fff", "#34d399", "#fbbf24", "#f472b6", "#22d3ee"];
+  return (
+    <div style={{ display: "flex", alignItems: "center" }}>
+      {tints.map((tint, i) => {
+        const period = 150;
+        const local = (frame + 20 - i * 16 + period) % period;
+        const p = spring({ frame: local, fps, config: { damping: 15, stiffness: 220 }, durationInFrames: 30 });
+        const shown = Math.min(1, p);
+        return (
+          <div
+            key={tint}
+            style={{
+              width: 52,
+              height: 52,
+              borderRadius: 999,
+              marginLeft: i === 0 ? 0 : -14,
+              background: `linear-gradient(135deg, ${tint}, ${colors.surfaceStrong})`,
+              border: `3px solid ${colors.surface}`,
+              transform: `scale(${0.4 + shown * 0.6})`,
+              opacity: 0.25 + shown * 0.75,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 18,
+              fontWeight: 700,
+              color: "#0b1020",
+            }}
+          >
+            {String.fromCharCode(65 + i)}
+          </div>
+        );
+      })}
+      <div
+        style={{
+          marginLeft: 14,
+          padding: "7px 14px",
+          borderRadius: 999,
+          background: colors.accentSoft,
+          border: `1px solid ${colors.borderStrong}`,
+          color: colors.accentText,
+          fontSize: 15,
+          fontWeight: 700,
+        }}
+      >
+        +24 online
+      </div>
+    </div>
+  );
+};
+
+export const Showcase: React.FC<z.infer<typeof showcaseSchema>> = ({ heading, kicker }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const headIn = enter({ frame, fps, delay: 4 });
+  const tiles: Array<{ label: string; node: React.ReactNode }> = [
+    { label: "Buttons & CTAs", node: <ButtonsDemo /> },
+    { label: "Switches & inputs", node: <ToggleDemo /> },
+    { label: "Charts & data", node: <ChartDemo /> },
+    { label: "Kanban & boards", node: <KanbanDemo /> },
+    { label: "AI & chat", node: <ComposerDemo /> },
+    { label: "Presence & avatars", node: <AvatarsDemo /> },
+  ];
+  return (
+    <Stage glowY="12%">
+      <AbsoluteFill style={{ alignItems: "center", paddingTop: 44 }}>
+        <Badge delay={0}>{kicker}</Badge>
+        <div
+          style={{
+            marginTop: 18,
+            marginBottom: 30,
+            fontSize: 52,
+            fontWeight: 800,
+            letterSpacing: -1.5,
+            color: colors.fg,
+            opacity: headIn,
+            transform: `translateY(${interpolate(headIn, [0, 1], [22, 0])}px)`,
+          }}
+        >
+          {heading}
+        </div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(3, 344px)",
+            gap: 22,
+          }}
+        >
+          {tiles.map((tile, i) => (
+            <Tile key={tile.label} label={tile.label} delay={16 + i * 6}>
+              {tile.node}
+            </Tile>
+          ))}
+        </div>
+      </AbsoluteFill>
+    </Stage>
+  );
+};

--- a/tools/promo/src/comps/category/Layout.tsx
+++ b/tools/promo/src/comps/category/Layout.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+import { AbsoluteFill, interpolate, useCurrentFrame, useVideoConfig } from "remotion";
+import { z } from "zod";
+import { enter } from "../../helpers";
+import { colors } from "../../theme";
+import { Badge, Stage } from "../../shared";
+
+export const categorySchema = z.object({
+  kicker: z.string(),
+  heading: z.string(),
+  sub: z.string(),
+});
+
+export type CategoryText = z.infer<typeof categorySchema>;
+
+export type CategoryTile = {
+  /** Real catalog component name — shown in the tile's label bar. */
+  label: string;
+  demo: React.FC;
+};
+
+export const CatTile: React.FC<{ tile: CategoryTile; delay: number }> = ({ tile, delay }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const p = enter({ frame, fps, delay });
+  const Demo = tile.demo;
+  return (
+    <div
+      style={{
+        width: 364,
+        height: 384,
+        borderRadius: 20,
+        border: `1px solid ${colors.border}`,
+        background: colors.surface,
+        boxShadow: "0 18px 50px rgba(0,0,0,0.42)",
+        overflow: "hidden",
+        position: "relative",
+        opacity: p,
+        transform: `translateY(${interpolate(p, [0, 1], [40, 0])}px) scale(${interpolate(p, [0, 1], [0.95, 1])})`,
+      }}
+    >
+      <div
+        style={{
+          height: 328,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          overflow: "hidden",
+        }}
+      >
+        <Demo />
+      </div>
+      <div
+        style={{
+          position: "absolute",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          height: 56,
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          padding: "0 20px",
+          fontSize: 17,
+          fontWeight: 600,
+          letterSpacing: 0.2,
+          color: colors.fgSecondary,
+          borderTop: `1px solid ${colors.border}`,
+          background: colors.bgElevated,
+        }}
+      >
+        <span
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: 999,
+            background: colors.accent,
+            boxShadow: `0 0 10px ${colors.accent}`,
+          }}
+        />
+        {tile.label}
+      </div>
+    </div>
+  );
+};
+
+export const CategoryShowcase: React.FC<CategoryText & { tiles: CategoryTile[] }> = ({
+  kicker,
+  heading,
+  sub,
+  tiles,
+}) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const headIn = enter({ frame, fps, delay: 4 });
+  const subIn = enter({ frame, fps, delay: 12 });
+  return (
+    <Stage glowY="10%">
+      <AbsoluteFill style={{ alignItems: "center", paddingTop: 36 }}>
+        <Badge delay={0}>{kicker}</Badge>
+        <div
+          style={{
+            marginTop: 14,
+            fontSize: 46,
+            fontWeight: 800,
+            letterSpacing: -1.4,
+            color: colors.fg,
+            opacity: headIn,
+            transform: `translateY(${interpolate(headIn, [0, 1], [20, 0])}px)`,
+          }}
+        >
+          {heading}
+        </div>
+        <div
+          style={{
+            marginTop: 8,
+            marginBottom: 26,
+            fontSize: 21,
+            fontWeight: 500,
+            color: colors.muted,
+            opacity: subIn,
+            transform: `translateY(${interpolate(subIn, [0, 1], [14, 0])}px)`,
+          }}
+        >
+          {sub}
+        </div>
+        <div style={{ display: "flex", gap: 24 }}>
+          {tiles.map((tile, i) => (
+            <CatTile key={tile.label} tile={tile} delay={18 + i * 7} />
+          ))}
+        </div>
+      </AbsoluteFill>
+    </Stage>
+  );
+};
+
+/** Builds a registered-composition config from text + three tile demos. */
+export const makeCategory = (
+  id: string,
+  defaults: CategoryText,
+  tiles: CategoryTile[],
+): {
+  id: string;
+  defaults: CategoryText;
+  component: React.FC<CategoryText>;
+} => ({
+  id,
+  defaults,
+  component: (props: CategoryText) => <CategoryShowcase {...props} tiles={tiles} />,
+});

--- a/tools/promo/src/comps/category/demos-ai-dev.tsx
+++ b/tools/promo/src/comps/category/demos-ai-dev.tsx
@@ -1,0 +1,236 @@
+import React from "react";
+import { useCurrentFrame } from "remotion";
+import { monoFamily, colors } from "../../theme";
+import { Bar, CheckDot, Chip, clamp01, Panel, Skel, spinnerGlyph } from "./ui";
+
+// AI interfaces + Developer tools micro-demos.
+
+export const ResponseStreamDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const lines = [220, 260, 180, 240, 130];
+  const period = 210;
+  const local = frame % period;
+  const chars = local * 3.2;
+  let used = 0;
+  return (
+    <Panel width={300} glow={0.35}>
+      <div style={{ display: "flex", alignItems: "center", gap: 9, marginBottom: 13 }}>
+        <div
+          style={{
+            width: 26,
+            height: 26,
+            borderRadius: 8,
+            background: `linear-gradient(135deg, ${colors.accent}, #315fea)`,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 13,
+            fontWeight: 800,
+            color: "#fff",
+          }}
+        >
+          ✦
+        </div>
+        <Skel w={90} h={9} tone="bright" />
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        {lines.map((w, i) => {
+          const grown = clamp01((chars - used) / w) * w;
+          used += w;
+          return <Skel key={i} w={Math.max(2, grown)} h={9} tone={i === 0 ? "accent" : "muted"} />;
+        })}
+      </div>
+      <div
+        style={{
+          marginTop: 12,
+          width: 9,
+          height: 16,
+          background: Math.floor(frame / 14) % 2 === 0 ? colors.accentText : "transparent",
+        }}
+      />
+    </Panel>
+  );
+};
+
+export const ToolCallDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const calls = [
+    { fn: "search_docs()", at: 0 },
+    { fn: "read_file()", at: 55 },
+    { fn: "run_tests()", at: 110 },
+  ];
+  const period = 200;
+  const local = frame % period;
+  return (
+    <Panel width={300}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 13 }}>
+        {calls.map((c) => {
+          const started = local >= c.at;
+          const done = local >= c.at + 42;
+          return (
+            <div
+              key={c.fn}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 11,
+                opacity: started ? 1 : 0.25,
+                transform: `translateX(${started ? 0 : 8}px)`,
+              }}
+            >
+              <CheckDot p={done ? 1 : 0} size={22} />
+              <span style={{ fontFamily: monoFamily, fontSize: 15.5, color: done ? colors.fgSecondary : colors.fg }}>
+                {c.fn}
+              </span>
+              {started && !done && (
+                <span style={{ color: colors.accentText, fontSize: 15 }}>{spinnerGlyph(frame)}</span>
+              )}
+              {done && (
+                <span style={{ marginLeft: "auto", fontSize: 12.5, fontWeight: 700, color: colors.muted }}>
+                  {(0.3 + (c.at % 3) * 0.4).toFixed(1)}s
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </Panel>
+  );
+};
+
+export const PipelineDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const stages = ["lint", "build", "e2e", "deploy"];
+  const period = 190;
+  const local = frame % period;
+  const per = 40;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 15, width: 290 }}>
+      {stages.map((s, i) => {
+        const p = clamp01((local - i * per) / 26);
+        const running = local >= i * per && p < 1;
+        return (
+          <div key={s} style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <CheckDot p={p} size={24} />
+            <span
+              style={{
+                fontFamily: monoFamily,
+                fontSize: 15.5,
+                width: 70,
+                color: p >= 1 ? colors.muted : colors.fg,
+              }}
+            >
+              {s}
+            </span>
+            <Bar value={p} width={130} color={p >= 1 ? colors.success : colors.accent} />
+            {running && <span style={{ color: colors.accentText }}>{spinnerGlyph(frame)}</span>}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+const LOG_LINES: Array<{ level: string; text: string }> = [
+  { level: "INFO", text: "server listening :3000" },
+  { level: "INFO", text: "GET /api/health 200" },
+  { level: "WARN", text: "cache miss user:42" },
+  { level: "INFO", text: "POST /api/orders 201" },
+  { level: "INFO", text: "job queue drained" },
+  { level: "ERR ", text: "retrying webhook (1/3)" },
+  { level: "INFO", text: "webhook delivered" },
+  { level: "INFO", text: "GET /api/feed 200" },
+];
+
+export const LogStreamDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const shown = Math.floor(frame / 16);
+  const levelColor = (l: string) =>
+    l === "WARN" ? colors.amber : l.trim() === "ERR" ? "#f87171" : colors.success;
+  return (
+    <Panel width={306} style={{ height: 240, overflow: "hidden", padding: "14px 16px" }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 9, justifyContent: "flex-end", height: "100%" }}>
+        {Array.from({ length: 8 }, (_, i) => {
+          const idx = shown - 7 + i;
+          if (idx < 0) return <div key={i} style={{ height: 15 }} />;
+          const line = LOG_LINES[idx % LOG_LINES.length];
+          const fresh = i === 7;
+          return (
+            <div
+              key={i}
+              style={{
+                fontFamily: monoFamily,
+                fontSize: 13.5,
+                display: "flex",
+                gap: 9,
+                opacity: fresh ? clamp01((frame % 16) / 6) : 0.45 + i * 0.07,
+              }}
+            >
+              <span style={{ color: levelColor(line.level), fontWeight: 700 }}>{line.level}</span>
+              <span style={{ color: colors.fgSecondary }}>{line.text}</span>
+            </div>
+          );
+        })}
+      </div>
+    </Panel>
+  );
+};
+
+export const EnvSwitcherDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const envs = ["dev", "staging", "prod"];
+  const period = 80;
+  const active = Math.floor(frame / period) % 3;
+  const local = frame % period;
+  const slide = clamp01(local / 14);
+  const prev = (active + 2) % 3;
+  const thumbX = (prev + (active - prev) * slide) * 92;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 20 }}>
+      <div
+        style={{
+          position: "relative",
+          display: "flex",
+          borderRadius: 12,
+          border: `1px solid ${colors.borderStrong}`,
+          background: colors.bgElevated,
+          padding: 4,
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: 4,
+            left: 4 + thumbX,
+            width: 88,
+            height: 40,
+            borderRadius: 9,
+            background: colors.accent,
+            opacity: 0.9,
+          }}
+        />
+        {envs.map((e, i) => (
+          <div
+            key={e}
+            style={{
+              position: "relative",
+              width: 92,
+              height: 40,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 15.5,
+              fontWeight: 700,
+              color: i === active ? "#fff" : colors.muted,
+            }}
+          >
+            {e}
+          </div>
+        ))}
+      </div>
+      <Chip color={active === 2 ? colors.amber : colors.success}>
+        ● {active === 2 ? "production — guarded" : "connected"}
+      </Chip>
+    </div>
+  );
+};

--- a/tools/promo/src/comps/category/demos-backgrounds.tsx
+++ b/tools/promo/src/comps/category/demos-backgrounds.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { useCurrentFrame } from "remotion";
+import { seededRandom } from "../../helpers";
+import { colors } from "../../theme";
+
+// Product Backgrounds — miniature versions of the animated background components.
+
+export const TopologyFieldDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const rand = seededRandom(11);
+  const nodes = Array.from({ length: 9 }, () => ({
+    x: 30 + rand() * 260,
+    y: 30 + rand() * 220,
+  }));
+  const edges: Array<[number, number]> = [
+    [0, 2], [1, 2], [2, 4], [3, 4], [4, 6], [5, 6], [6, 8], [4, 7], [1, 5],
+  ];
+  return (
+    <svg width={320} height={280} viewBox="0 0 320 280">
+      {edges.map(([a, b], i) => {
+        const pulse = ((frame * 1.6 + i * 37) % 130) / 130;
+        const na = nodes[a];
+        const nb = nodes[b];
+        const px = na.x + (nb.x - na.x) * pulse;
+        const py = na.y + (nb.y - na.y) * pulse;
+        return (
+          <g key={i}>
+            <line x1={na.x} y1={na.y} x2={nb.x} y2={nb.y} stroke={colors.border} strokeWidth={1.5} />
+            <circle cx={px} cy={py} r={3} fill={colors.accentText} opacity={0.9} />
+          </g>
+        );
+      })}
+      {nodes.map((n, i) => {
+        const glow = 0.5 + 0.5 * Math.sin(frame / 18 + i * 1.7);
+        return (
+          <g key={i}>
+            <circle cx={n.x} cy={n.y} r={10 + glow * 4} fill={colors.accent} opacity={0.12 * glow} />
+            <circle cx={n.x} cy={n.y} r={5} fill={colors.surfaceStrong} stroke={colors.accent} strokeWidth={1.5} />
+          </g>
+        );
+      })}
+    </svg>
+  );
+};
+
+export const QueueLanesDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const lanes = [
+    { label: "ingest", speed: 2.4, count: 3, offset: 0 },
+    { label: "transform", speed: 1.7, count: 2, offset: 60 },
+    { label: "index", speed: 3.0, count: 3, offset: 130 },
+    { label: "deliver", speed: 2.0, count: 2, offset: 30 },
+  ];
+  const laneWidth = 300;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 26, width: laneWidth }}>
+      {lanes.map((lane, li) => (
+        <div key={lane.label}>
+          <div style={{ fontSize: 13, fontWeight: 700, color: colors.muted, marginBottom: 8, letterSpacing: 1 }}>
+            {lane.label.toUpperCase()}
+          </div>
+          <div
+            style={{
+              position: "relative",
+              height: 14,
+              borderRadius: 7,
+              background: colors.bgElevated,
+              border: `1px solid ${colors.border}`,
+              overflow: "hidden",
+            }}
+          >
+            {Array.from({ length: lane.count }, (_, i) => {
+              const span = laneWidth + 70;
+              const x = ((frame * lane.speed + lane.offset + (i * span) / lane.count) % span) - 60;
+              return (
+                <div
+                  key={i}
+                  style={{
+                    position: "absolute",
+                    left: x,
+                    top: 2,
+                    width: 54,
+                    height: 8,
+                    borderRadius: 4,
+                    background: `linear-gradient(90deg, transparent, ${li % 2 === 0 ? colors.accent : colors.accentText})`,
+                    opacity: 0.9,
+                  }}
+                />
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export const ContourSurfaceDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const rings = 7;
+  return (
+    <svg width={320} height={280} viewBox="0 0 320 280">
+      {Array.from({ length: rings }, (_, i) => {
+        const t = frame / 40;
+        const base = 26 + i * 20;
+        const points = Array.from({ length: 48 }, (_, k) => {
+          const a = (k / 48) * Math.PI * 2;
+          const wobble =
+            Math.sin(a * 3 + t + i * 0.8) * 7 + Math.sin(a * 5 - t * 1.3 + i) * 4;
+          const r = base + wobble;
+          return `${160 + Math.cos(a) * r * 1.15},${140 + Math.sin(a) * r * 0.82}`;
+        }).join(" ");
+        const bright = i === Math.floor((frame / 26) % rings);
+        return (
+          <polygon
+            key={i}
+            points={points}
+            fill="none"
+            stroke={bright ? colors.accentText : colors.borderStrong}
+            strokeWidth={bright ? 2.2 : 1.4}
+            opacity={bright ? 0.95 : 0.85}
+          />
+        );
+      })}
+    </svg>
+  );
+};

--- a/tools/promo/src/comps/category/demos-collab-data.tsx
+++ b/tools/promo/src/comps/category/demos-collab-data.tsx
@@ -1,0 +1,344 @@
+import React from "react";
+import { interpolate, spring, useCurrentFrame, useVideoConfig } from "remotion";
+import { colors } from "../../theme";
+import { CheckDot, Chip, clamp01, Panel, Skel } from "./ui";
+
+// Collaboration + Data motion + Productivity micro-demos.
+
+export const CommentThreadDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const period = 220;
+  const local = frame % period;
+  const bubbles = [
+    { tint: "#7f9fff", w: 200, at: 0, mine: false },
+    { tint: "#34d399", w: 160, at: 55, mine: true },
+    { tint: "#7f9fff", w: 180, at: 130, mine: false },
+  ];
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 13, width: 290 }}>
+      {bubbles.map((b, i) => {
+        const p = spring({ frame: local - b.at, fps, config: { damping: 18, stiffness: 220 } });
+        const typing = local >= b.at - 28 && local < b.at;
+        return (
+          <div key={i} style={{ display: "flex", justifyContent: b.mine ? "flex-end" : "flex-start" }}>
+            {typing ? (
+              <div style={{ display: "flex", gap: 5, padding: "12px 16px", borderRadius: 14, background: colors.surfaceStrong }}>
+                {[0, 1, 2].map((d) => (
+                  <div
+                    key={d}
+                    style={{
+                      width: 7,
+                      height: 7,
+                      borderRadius: 999,
+                      background: colors.muted,
+                      transform: `translateY(${Math.sin((local + d * 6) / 5) * -3}px)`,
+                    }}
+                  />
+                ))}
+              </div>
+            ) : local >= b.at ? (
+              <div
+                style={{
+                  display: "flex",
+                  gap: 10,
+                  alignItems: "flex-start",
+                  opacity: p,
+                  transform: `translateY(${(1 - p) * 14}px) scale(${0.9 + p * 0.1})`,
+                  flexDirection: b.mine ? "row-reverse" : "row",
+                }}
+              >
+                <div style={{ width: 30, height: 30, borderRadius: 999, background: `linear-gradient(135deg, ${b.tint}, ${colors.surfaceStrong})`, flexShrink: 0 }} />
+                <div
+                  style={{
+                    padding: "11px 14px",
+                    borderRadius: 14,
+                    background: b.mine ? colors.accent : colors.surfaceRaised,
+                    border: `1px solid ${b.mine ? colors.accentHover : colors.borderStrong}`,
+                  }}
+                >
+                  <Skel w={b.w * 0.8} h={7} tone={b.mine ? "bright" : "muted"} />
+                  <Skel w={b.w * 0.55} h={7} tone={b.mine ? "bright" : "muted"} style={{ marginTop: 6, opacity: 0.7 }} />
+                </div>
+              </div>
+            ) : (
+              <div style={{ height: 30 }} />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export const ApprovalDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const period = 200;
+  const local = frame % period;
+  const steps = [
+    { label: "Requested", by: "M", at: 0 },
+    { label: "Reviewed", by: "A", at: 60 },
+    { label: "Approved", by: "S", at: 120 },
+  ];
+  return (
+    <Panel width={296}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+        {steps.map((s, i) => {
+          const p = clamp01((local - s.at) / 20);
+          return (
+            <div key={s.label} style={{ display: "flex", gap: 14 }}>
+              <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+                <CheckDot p={p} size={26} color={i === 2 ? colors.accent : colors.success} />
+                {i < 2 && (
+                  <div style={{ width: 3, height: 34, background: colors.surfaceStrong, borderRadius: 2, overflow: "hidden" }}>
+                    <div style={{ width: "100%", height: `${clamp01((local - s.at - 16) / 40) * 100}%`, background: colors.accent }} />
+                  </div>
+                )}
+              </div>
+              <div style={{ paddingTop: 2, opacity: 0.35 + p * 0.65 }}>
+                <div style={{ fontSize: 16.5, fontWeight: 700, color: p > 0 ? colors.fg : colors.muted }}>{s.label}</div>
+                <div style={{ fontSize: 13.5, color: colors.muted, marginTop: 2 }}>by teammate {s.by} · just now</div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Panel>
+  );
+};
+
+export const KpiMorphDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const period = 90;
+  const step = Math.floor(frame / period) % 3;
+  const local = frame % period;
+  const targets = [12480, 15920, 14210];
+  const prev = targets[(step + 2) % 3];
+  const cur = targets[step];
+  const t = clamp01(local / 34);
+  const eased = 1 - (1 - t) * (1 - t) * (1 - t);
+  const value = Math.round(prev + (cur - prev) * eased);
+  const up = cur > prev;
+  const pop = spring({ frame: local - 4, fps, config: { damping: 15, stiffness: 240 }, durationInFrames: 26 });
+  return (
+    <div style={{ textAlign: "center" }}>
+      <div style={{ fontSize: 15, fontWeight: 700, letterSpacing: 1.5, color: colors.muted, marginBottom: 10 }}>
+        MONTHLY REVENUE
+      </div>
+      <div style={{ fontSize: 58, fontWeight: 800, color: colors.fg, fontVariantNumeric: "tabular-nums", letterSpacing: -2 }}>
+        ${value.toLocaleString("en-US")}
+      </div>
+      <div style={{ marginTop: 12, display: "inline-block", transform: `scale(${0.8 + clamp01(pop) * 0.2})` }}>
+        <Chip color={up ? colors.success : "#f87171"}>
+          {up ? "▲" : "▼"} {Math.abs(Math.round(((cur - prev) / prev) * 100))}% vs last month
+        </Chip>
+      </div>
+    </div>
+  );
+};
+
+export const StreamingRowsDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const rowH = 46;
+  const every = 34;
+  const shown = Math.floor(frame / every);
+  const tints = ["#7f9fff", "#34d399", "#fbbf24", "#f472b6", "#22d3ee", "#a78bfa"];
+  return (
+    <div style={{ width: 300, height: 250, overflow: "hidden", display: "flex", flexDirection: "column", gap: 8 }}>
+      {Array.from({ length: 6 }, (_, i) => {
+        const idx = shown - i;
+        if (idx < 0) return <div key={i} style={{ height: rowH }} />;
+        const isNew = i === 0;
+        const p = isNew
+          ? spring({ frame: frame - shown * every, fps, config: { damping: 20, stiffness: 240 } })
+          : 1;
+        const tint = tints[((idx % tints.length) + tints.length) % tints.length];
+        return (
+          <div
+            key={idx}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 12,
+              height: rowH,
+              padding: "0 14px",
+              borderRadius: 11,
+              border: `1px solid ${isNew ? colors.accent : colors.border}`,
+              background: isNew ? colors.surfaceRaised : colors.bgElevated,
+              opacity: Math.max(0.25, 1 - i * 0.14) * p,
+              transform: `translateY(${(1 - p) * -rowH}px)`,
+            }}
+          >
+            <div style={{ width: 9, height: 9, borderRadius: 999, background: tint }} />
+            <Skel w={90 + ((idx * 37) % 60)} h={8} tone={isNew ? "bright" : "muted"} />
+            <div style={{ marginLeft: "auto", fontSize: 13.5, fontWeight: 700, color: isNew ? colors.accentText : colors.muted, fontVariantNumeric: "tabular-nums" }}>
+              +{(idx % 9) + 1}.{(idx * 7) % 10}k
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export const FilterTransitionDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const period = 110;
+  const filtered = Math.floor(frame / period) % 2 === 1;
+  const local = frame % period;
+  const t = spring({ frame: local - 10, fps, config: { damping: 20, stiffness: 190 } });
+  const m = filtered ? t : 1 - t;
+  const cells = Array.from({ length: 9 }, (_, i) => i);
+  const keep = [0, 2, 4, 7];
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 16 }}>
+      <div style={{ display: "flex", gap: 8 }}>
+        {["All", "Active"].map((f, i) => (
+          <div
+            key={f}
+            style={{
+              padding: "7px 16px",
+              borderRadius: 999,
+              fontSize: 14,
+              fontWeight: 700,
+              border: `1px solid ${colors.borderStrong}`,
+              background: (i === 1) === filtered ? colors.accent : colors.bgElevated,
+              color: (i === 1) === filtered ? "#fff" : colors.muted,
+            }}
+          >
+            {f}
+          </div>
+        ))}
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 84px)", gap: 10 }}>
+        {cells.map((i) => {
+          const kept = keep.includes(i);
+          const gone = kept ? 0 : m;
+          return (
+            <div
+              key={i}
+              style={{
+                height: 54,
+                borderRadius: 10,
+                border: `1px solid ${kept && m > 0.5 ? colors.accent : colors.border}`,
+                background: colors.bgElevated,
+                opacity: 1 - gone * 0.92,
+                transform: `scale(${1 - gone * 0.35})`,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <Skel w={44} h={7} tone={kept && m > 0.5 ? "accent" : "muted"} />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export const DependencyMapDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const period = 180;
+  const local = frame % period;
+  const nodes = [
+    { x: 50, y: 60, at: 0 },
+    { x: 50, y: 180, at: 20 },
+    { x: 150, y: 120, at: 55 },
+    { x: 250, y: 60, at: 95 },
+    { x: 250, y: 180, at: 95 },
+  ];
+  const edges: Array<[number, number]> = [[0, 2], [1, 2], [2, 3], [2, 4]];
+  return (
+    <svg width={300} height={240} viewBox="0 0 300 240">
+      {edges.map(([a, b], i) => {
+        const from = nodes[a];
+        const to = nodes[b];
+        const p = clamp01((local - to.at + 30) / 30);
+        return (
+          <line
+            key={i}
+            x1={from.x}
+            y1={from.y}
+            x2={from.x + (to.x - from.x) * p}
+            y2={from.y + (to.y - from.y) * p}
+            stroke={p >= 1 ? colors.accent : colors.borderStrong}
+            strokeWidth={2.5}
+          />
+        );
+      })}
+      {nodes.map((n, i) => {
+        const done = clamp01((local - n.at) / 16);
+        return (
+          <g key={i}>
+            <rect
+              x={n.x - 34}
+              y={n.y - 20}
+              width={68}
+              height={40}
+              rx={10}
+              fill={done > 0 ? colors.surfaceRaised : colors.bgElevated}
+              stroke={done > 0.5 ? colors.accent : colors.borderStrong}
+              strokeWidth={1.6}
+              opacity={0.4 + done * 0.6}
+            />
+            <rect x={n.x - 20} y={n.y - 4} width={40} height={8} rx={4} fill={done > 0.5 ? colors.accentText : colors.surfaceStrong} opacity={0.9} />
+          </g>
+        );
+      })}
+    </svg>
+  );
+};
+
+export const ProjectTimelineDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const period = 190;
+  const local = frame % period;
+  const playhead = interpolate(local, [0, period], [0, 280]);
+  const rows = [
+    { start: 0, len: 120, tint: colors.accent, at: 0 },
+    { start: 60, len: 140, tint: "#34d399", at: 22 },
+    { start: 130, len: 110, tint: "#fbbf24", at: 44 },
+    { start: 200, len: 80, tint: "#f472b6", at: 66 },
+  ];
+  return (
+    <div style={{ position: "relative", width: 292, padding: "10px 0" }}>
+      {rows.map((r, i) => {
+        const grow = clamp01((local - r.at) / 34);
+        return (
+          <div key={i} style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 16 }}>
+            <Skel w={34} h={7} />
+            <div style={{ position: "relative", flex: 1, height: 22 }}>
+              <div
+                style={{
+                  position: "absolute",
+                  left: r.start * 0.82,
+                  width: r.len * 0.82 * grow,
+                  height: 22,
+                  borderRadius: 7,
+                  background: `linear-gradient(90deg, ${r.tint}, ${r.tint}cc)`,
+                  opacity: 0.9,
+                }}
+              />
+            </div>
+          </div>
+        );
+      })}
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          bottom: 0,
+          left: 44 + playhead * 0.82,
+          width: 2,
+          background: colors.fgSecondary,
+          opacity: 0.65,
+        }}
+      />
+    </div>
+  );
+};

--- a/tools/promo/src/comps/category/demos-flows.tsx
+++ b/tools/promo/src/comps/category/demos-flows.tsx
@@ -1,0 +1,650 @@
+import React from "react";
+import { spring, useCurrentFrame, useVideoConfig } from "remotion";
+import { colors, monoFamily } from "../../theme";
+import { Bar, CheckDot, Chip, clamp01, Panel, Skel, spinnerGlyph } from "./ui";
+
+// File workflows + Commerce + Security & accounts + Communication micro-demos.
+
+const FileRow: React.FC<{ name: string; size: string; progress: number; frame: number }> = ({
+  name,
+  size,
+  progress,
+  frame,
+}) => (
+  <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+    <div
+      style={{
+        width: 36,
+        height: 36,
+        borderRadius: 9,
+        background: colors.surfaceStrong,
+        border: `1px solid ${colors.borderStrong}`,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: 11,
+        fontWeight: 800,
+        color: colors.accentText,
+        flexShrink: 0,
+      }}
+    >
+      {name.split(".").pop()?.toUpperCase()}
+    </div>
+    <div style={{ flex: 1 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 7 }}>
+        <span style={{ fontSize: 14.5, fontWeight: 600, color: colors.fgSecondary }}>{name}</span>
+        <span style={{ fontSize: 12.5, color: colors.muted }}>
+          {progress >= 1 ? size : `${Math.round(clamp01(progress) * 100)}%`}
+        </span>
+      </div>
+      <Bar value={progress} width={190} color={progress >= 1 ? colors.success : colors.accent} />
+    </div>
+    <CheckDot p={progress >= 1 ? clamp01((progress - 1) * 10 + 1) : 0} size={22} />
+    {progress > 0 && progress < 1 && (
+      <span style={{ color: colors.accentText, fontSize: 14, width: 0, marginLeft: -10 }}>
+        {spinnerGlyph(frame)}
+      </span>
+    )}
+  </div>
+);
+
+export const MultiFileQueueDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const period = 210;
+  const local = frame % period;
+  const files = [
+    { name: "brand-video.mp4", size: "48 MB", at: 0, dur: 90 },
+    { name: "hero-shot.png", size: "2.1 MB", at: 24, dur: 50 },
+    { name: "report-q3.pdf", size: "830 KB", at: 48, dur: 40 },
+  ];
+  return (
+    <Panel width={306}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 17 }}>
+        {files.map((f) => (
+          <FileRow
+            key={f.name}
+            name={f.name}
+            size={f.size}
+            progress={clamp01((local - f.at) / f.dur)}
+            frame={frame}
+          />
+        ))}
+      </div>
+    </Panel>
+  );
+};
+
+export const ProcessingTimelineDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const period = 200;
+  const local = frame % period;
+  const steps = [
+    { label: "Upload", at: 0 },
+    { label: "Virus scan", at: 44 },
+    { label: "Transcode", at: 88 },
+    { label: "Publish", at: 140 },
+  ];
+  return (
+    <Panel width={290}>
+      {steps.map((s, i) => {
+        const p = clamp01((local - s.at) / 26);
+        const running = local >= s.at && p < 1;
+        return (
+          <div key={s.label} style={{ display: "flex", gap: 13 }}>
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+              <CheckDot p={p} size={24} />
+              {i < steps.length - 1 && (
+                <div style={{ width: 3, height: 26, background: colors.surfaceStrong, borderRadius: 2, overflow: "hidden" }}>
+                  <div style={{ width: "100%", height: `${clamp01((local - s.at - 20) / 24) * 100}%`, background: colors.accent }} />
+                </div>
+              )}
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 9, height: 24, opacity: 0.35 + clamp01((local - s.at + 10) / 12) * 0.65 }}>
+              <span style={{ fontSize: 16, fontWeight: 700, color: p >= 1 ? colors.muted : colors.fg }}>{s.label}</span>
+              {running && <span style={{ color: colors.accentText, fontSize: 14 }}>{spinnerGlyph(frame)}</span>}
+            </div>
+          </div>
+        );
+      })}
+    </Panel>
+  );
+};
+
+export const VariantSelectorDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const swatches = ["#4f7cff", "#34d399", "#fbbf24", "#f472b6"];
+  const period = 62;
+  const active = Math.floor(frame / period) % swatches.length;
+  const local = frame % period;
+  const settle = spring({ frame: local, fps, config: { damping: 16, stiffness: 260 }, durationInFrames: 24 });
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 20 }}>
+      <div
+        style={{
+          width: 130,
+          height: 130,
+          borderRadius: 22,
+          background: `linear-gradient(145deg, ${swatches[active]}, ${colors.surfaceStrong})`,
+          border: `1px solid ${colors.borderStrong}`,
+          boxShadow: `0 16px 44px ${swatches[active]}44`,
+          transform: `scale(${0.94 + clamp01(settle) * 0.06})`,
+          display: "flex",
+          alignItems: "flex-end",
+          padding: 14,
+        }}
+      >
+        <Skel w={54} h={9} tone="bright" />
+      </div>
+      <div style={{ display: "flex", gap: 13 }}>
+        {swatches.map((c, i) => (
+          <div
+            key={c}
+            style={{
+              width: 34,
+              height: 34,
+              borderRadius: 999,
+              background: c,
+              border: `3px solid ${i === active ? colors.fg : "transparent"}`,
+              transform: `scale(${i === active ? 0.95 + clamp01(settle) * 0.15 : 1})`,
+              boxShadow: i === active ? `0 0 18px ${c}88` : "none",
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export const CheckoutProgressDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const period = 210;
+  const local = frame % period;
+  const steps = ["Cart", "Shipping", "Payment"];
+  const per = 58;
+  return (
+    <Panel width={296}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 20 }}>
+        {steps.map((s, i) => {
+          const p = clamp01((local - i * per) / 20);
+          return (
+            <React.Fragment key={s}>
+              {i > 0 && (
+                <div style={{ flex: 1, height: 3, margin: "0 8px", borderRadius: 2, background: colors.surfaceStrong, overflow: "hidden" }}>
+                  <div style={{ width: `${clamp01((local - (i - 1) * per - 20) / 34) * 100}%`, height: "100%", background: colors.accent }} />
+                </div>
+              )}
+              <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 7 }}>
+                <CheckDot p={p} size={26} color={colors.accent} />
+                <span style={{ fontSize: 13, fontWeight: 700, color: p > 0 ? colors.fg : colors.muted }}>{s}</span>
+              </div>
+            </React.Fragment>
+          );
+        })}
+      </div>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <div>
+          <div style={{ fontSize: 13, color: colors.muted, marginBottom: 4 }}>Total</div>
+          <div style={{ fontSize: 24, fontWeight: 800, color: colors.fg, fontVariantNumeric: "tabular-nums" }}>
+            $149.00
+          </div>
+        </div>
+        <div
+          style={{
+            padding: "11px 22px",
+            borderRadius: 11,
+            background: local > 3 * per ? colors.success : colors.accent,
+            color: local > 3 * per ? "#0b1020" : "#fff",
+            fontSize: 15.5,
+            fontWeight: 700,
+          }}
+        >
+          {local > 3 * per ? "✓ Order placed" : "Continue"}
+        </div>
+      </div>
+    </Panel>
+  );
+};
+
+export const TwoFactorDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const period = 190;
+  const local = frame % period;
+  const code = [7, 3, 9, 1, 4, 2];
+  const startAt = 18;
+  const per = 13;
+  const filled = Math.floor(clamp01((local - startAt) / (per * 6)) * 6);
+  const verified = local > startAt + per * 6 + 22;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 22 }}>
+      <div style={{ fontSize: 15.5, fontWeight: 600, color: colors.fgSecondary }}>
+        Enter the 6-digit code
+      </div>
+      <div style={{ display: "flex", gap: 9 }}>
+        {code.map((d, i) => {
+          const has = i < filled;
+          const activeBox = i === filled && !verified;
+          return (
+            <div
+              key={i}
+              style={{
+                width: 40,
+                height: 50,
+                borderRadius: 10,
+                border: `2px solid ${verified ? colors.success : activeBox ? colors.accent : colors.borderStrong}`,
+                background: colors.bgElevated,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontFamily: monoFamily,
+                fontSize: 23,
+                fontWeight: 700,
+                color: verified ? colors.success : colors.fg,
+                boxShadow: activeBox ? `0 0 16px ${colors.accent}66` : "none",
+              }}
+            >
+              {has ? d : ""}
+            </div>
+          );
+        })}
+      </div>
+      <div style={{ height: 36 }}>
+        {verified && (
+          <Chip color={colors.success} style={{ fontSize: 15 }}>
+            ✓ Identity verified
+          </Chip>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const PasskeyDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const period = 160;
+  const local = frame % period;
+  const scanning = local < 80;
+  const ringP = clamp01((local - 80) / 24);
+  const sweep = (local % 40) / 40;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 22 }}>
+      <div
+        style={{
+          position: "relative",
+          width: 120,
+          height: 120,
+          borderRadius: 999,
+          border: `3px solid ${scanning ? colors.accent : colors.success}`,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          boxShadow: `0 0 34px ${scanning ? colors.accent : colors.success}55`,
+          overflow: "hidden",
+        }}
+      >
+        {scanning && (
+          <div
+            style={{
+              position: "absolute",
+              left: 0,
+              right: 0,
+              top: `${sweep * 100}%`,
+              height: 3,
+              background: `linear-gradient(90deg, transparent, ${colors.accentText}, transparent)`,
+            }}
+          />
+        )}
+        {scanning ? (
+          <svg width={54} height={54} viewBox="0 0 24 24" fill="none" stroke={colors.accentText} strokeWidth={1.6} strokeLinecap="round">
+            <path d="M12 11a4 4 0 014 4v2M12 11a4 4 0 00-4 4v1M12 7.5A7.5 7.5 0 0119.5 15v1.5M12 7.5A7.5 7.5 0 004.5 15M12 14.5V19" />
+          </svg>
+        ) : (
+          <svg width={54} height={54} viewBox="0 0 24 24" fill="none">
+            <path
+              d="M4.5 12.5l5 5L19.5 7"
+              stroke={colors.success}
+              strokeWidth={2.6}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeDasharray={26}
+              strokeDashoffset={26 * (1 - ringP)}
+            />
+          </svg>
+        )}
+      </div>
+      <Chip color={scanning ? colors.accentText : colors.success} style={{ fontSize: 15 }}>
+        {scanning ? "Touch sensor to continue" : "✓ Passkey created"}
+      </Chip>
+    </div>
+  );
+};
+
+export const DeliveryStatesDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const period = 210;
+  const local = frame % period;
+  const sendAt = 14;
+  const p = spring({ frame: local - sendAt, fps, config: { damping: 19, stiffness: 210 } });
+  const stage = local < sendAt + 24 ? 0 : local < sendAt + 60 ? 1 : local < sendAt + 100 ? 2 : 3;
+  const ticks = ["🕐", "✓", "✓✓", "✓✓"];
+  const replyP = spring({ frame: local - 150, fps, config: { damping: 18, stiffness: 220 } });
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14, width: 280 }}>
+      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+        <div
+          style={{
+            padding: "12px 16px",
+            borderRadius: "16px 16px 4px 16px",
+            background: colors.accent,
+            opacity: p,
+            transform: `translateY(${(1 - p) * 18}px) scale(${0.92 + p * 0.08})`,
+          }}
+        >
+          <Skel w={140} h={8} tone="bright" />
+          <Skel w={90} h={8} tone="bright" style={{ marginTop: 7, opacity: 0.75 }} />
+          <div style={{ marginTop: 9, textAlign: "right", fontSize: 12.5, color: stage === 3 ? "#9fdcff" : "rgba(255,255,255,0.75)", fontWeight: 700 }}>
+            {ticks[stage]} {stage === 0 ? "sending" : stage === 1 ? "sent" : stage === 2 ? "delivered" : "read"}
+          </div>
+        </div>
+      </div>
+      {local >= 150 && (
+        <div style={{ display: "flex" }}>
+          <div
+            style={{
+              padding: "12px 16px",
+              borderRadius: "16px 16px 16px 4px",
+              background: colors.surfaceRaised,
+              border: `1px solid ${colors.borderStrong}`,
+              opacity: replyP,
+              transform: `translateY(${(1 - replyP) * 16}px)`,
+            }}
+          >
+            <Skel w={110} h={8} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const TypingPresenceDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const users = [
+    { name: "Alex", tint: "#7f9fff", typingAt: [0, 90] as [number, number] },
+    { name: "Sam", tint: "#34d399", typingAt: [110, 200] as [number, number] },
+  ];
+  const period = 220;
+  const local = frame % period;
+  return (
+    <Panel width={286}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
+        {users.map((u) => {
+          const typing = local >= u.typingAt[0] && local < u.typingAt[1];
+          const pulse = 0.6 + 0.4 * Math.sin(frame / 9);
+          return (
+            <div key={u.name} style={{ display: "flex", alignItems: "center", gap: 12 }}>
+              <div style={{ position: "relative" }}>
+                <div style={{ width: 40, height: 40, borderRadius: 999, background: `linear-gradient(135deg, ${u.tint}, ${colors.surfaceStrong})` }} />
+                <div
+                  style={{
+                    position: "absolute",
+                    right: -1,
+                    bottom: -1,
+                    width: 13,
+                    height: 13,
+                    borderRadius: 999,
+                    background: colors.success,
+                    border: `2.5px solid ${colors.bgElevated}`,
+                    transform: `scale(${typing ? pulse * 0.4 + 0.8 : 1})`,
+                  }}
+                />
+              </div>
+              <div>
+                <div style={{ fontSize: 16, fontWeight: 700, color: colors.fg }}>{u.name}</div>
+                <div style={{ fontSize: 13.5, color: typing ? colors.accentText : colors.muted, height: 18 }}>
+                  {typing ? (
+                    <span>
+                      typing
+                      {".".repeat((Math.floor(frame / 12) % 3) + 1)}
+                    </span>
+                  ) : (
+                    "online"
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Panel>
+  );
+};
+
+export const ThreadExpansionDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const period = 200;
+  const local = frame % period;
+  const expandAt = 40;
+  const collapseAt = 150;
+  const raw = spring({ frame: local - expandAt, fps, config: { damping: 21, stiffness: 180 } });
+  const back = spring({ frame: local - collapseAt, fps, config: { damping: 21, stiffness: 180 } });
+  const open = clamp01(raw - back);
+  const replies = [0, 1, 2];
+  return (
+    <div style={{ width: 286 }}>
+      <Panel width={286} style={{ padding: 14 }}>
+        <div style={{ display: "flex", gap: 11, alignItems: "center" }}>
+          <div style={{ width: 34, height: 34, borderRadius: 999, background: "linear-gradient(135deg, #7f9fff, #243249)", flexShrink: 0 }} />
+          <div>
+            <Skel w={150} h={8} tone="bright" />
+            <Skel w={100} h={7} style={{ marginTop: 6 }} />
+          </div>
+        </div>
+        <div style={{ marginTop: 11, fontSize: 13.5, fontWeight: 700, color: colors.accentText }}>
+          {open > 0.5 ? "▾" : "▸"} 3 replies
+        </div>
+      </Panel>
+      <div style={{ overflow: "hidden", height: open * 150, marginLeft: 22 }}>
+        {replies.map((r) => (
+          <div
+            key={r}
+            style={{
+              marginTop: 9,
+              padding: "10px 13px",
+              borderRadius: 11,
+              border: `1px solid ${colors.border}`,
+              background: colors.bgElevated,
+              borderLeft: `3px solid ${colors.accent}`,
+              opacity: clamp01(open * 3 - r * 0.7),
+              transform: `translateY(${(1 - open) * 10}px)`,
+            }}
+          >
+            <Skel w={140 - r * 20} h={7} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export const FileUploadPipelineDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const period = 190;
+  const local = frame % period;
+  const drop = spring({ frame: local - 6, fps, config: { damping: 15, stiffness: 210 } });
+  const progress = clamp01((local - 34) / 70);
+  const done = local > 120;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 18, width: 290 }}>
+      <div
+        style={{
+          width: 290,
+          height: 110,
+          borderRadius: 16,
+          border: `2px dashed ${done ? colors.success : colors.accent}`,
+          background: colors.bgElevated,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexDirection: "column",
+          gap: 8,
+        }}
+      >
+        <div
+          style={{
+            transform: `translateY(${(1 - drop) * -26}px) scale(${0.6 + drop * 0.4})`,
+            opacity: drop,
+          }}
+        >
+          {done ? (
+            <CheckDot p={1} size={34} />
+          ) : (
+            <svg width={34} height={34} viewBox="0 0 24 24" fill="none" stroke={colors.accentText} strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round">
+              <path d="M14 3H7a1.5 1.5 0 00-1.5 1.5v15A1.5 1.5 0 007 21h10a1.5 1.5 0 001.5-1.5V7.5L14 3z" />
+              <path d="M14 3v4.5h4.5M9 13h6M9 16.5h4" />
+            </svg>
+          )}
+        </div>
+        <span style={{ fontSize: 14, fontWeight: 600, color: colors.muted }}>
+          {done ? "Upload complete" : local < 34 ? "Drop file to upload" : "Uploading…"}
+        </span>
+      </div>
+      <div style={{ width: 250 }}>
+        <Bar value={done ? 1 : progress} width={250} color={done ? colors.success : colors.accent} />
+      </div>
+    </div>
+  );
+};
+
+export const CartTransitionDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const period = 200;
+  const local = frame % period;
+  const addAt = 30;
+  const p = spring({ frame: local - addAt, fps, config: { damping: 17, stiffness: 210 } });
+  const items = [
+    { tint: "#7f9fff", price: 59, base: true },
+    { tint: "#34d399", price: 90, base: false },
+  ];
+  const total = 59 + Math.round(clamp01(p) * 90);
+  return (
+    <Panel width={292}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        {items.map((item, i) => {
+          const vis = item.base ? 1 : clamp01(p);
+          return (
+            <div
+              key={i}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 12,
+                height: 52 * (item.base ? 1 : vis),
+                opacity: vis,
+                transform: `translateX(${(1 - vis) * 60}px)`,
+                overflow: "hidden",
+              }}
+            >
+              <div style={{ width: 42, height: 42, borderRadius: 10, background: `linear-gradient(135deg, ${item.tint}, ${colors.surfaceStrong})`, flexShrink: 0 }} />
+              <div>
+                <Skel w={110} h={8} tone="bright" />
+                <Skel w={64} h={7} style={{ marginTop: 6 }} />
+              </div>
+              <div style={{ marginLeft: "auto", fontSize: 16, fontWeight: 700, color: colors.fg, fontVariantNumeric: "tabular-nums" }}>
+                ${item.price}
+              </div>
+            </div>
+          );
+        })}
+        <div style={{ borderTop: `1px solid ${colors.border}`, paddingTop: 12, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <span style={{ fontSize: 14.5, fontWeight: 600, color: colors.muted }}>Total</span>
+          <span style={{ fontSize: 21, fontWeight: 800, color: colors.accentText, fontVariantNumeric: "tabular-nums" }}>
+            ${total}.00
+          </span>
+        </div>
+      </div>
+    </Panel>
+  );
+};
+
+export const SessionSecurityDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const period = 210;
+  const local = frame % period;
+  const revokeAt = 90;
+  const gone = spring({ frame: local - revokeAt, fps, config: { damping: 20, stiffness: 190 } });
+  const sessions = [
+    { device: "MacBook Pro", meta: "This device", safe: true },
+    { device: "iPhone 16", meta: "Berlin · now", safe: true },
+    { device: "Unknown device", meta: "Riga · 2m ago", safe: false },
+  ];
+  return (
+    <Panel width={296}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 11 }}>
+        {sessions.map((s) => {
+          const removing = !s.safe;
+          const vis = removing ? 1 - clamp01(gone) : 1;
+          return (
+            <div
+              key={s.device}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 12,
+                padding: "10px 12px",
+                borderRadius: 11,
+                border: `1px solid ${removing ? "#f87171" : colors.border}`,
+                background: removing ? "rgba(248,113,113,0.08)" : colors.surface,
+                height: 56 * vis,
+                opacity: vis,
+                transform: `translateX(${(1 - vis) * 80}px)`,
+                overflow: "hidden",
+              }}
+            >
+              <div
+                style={{
+                  width: 32,
+                  height: 32,
+                  borderRadius: 9,
+                  flexShrink: 0,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  background: removing ? "rgba(248,113,113,0.14)" : colors.accentSoft,
+                  border: `1px solid ${removing ? "#f87171" : colors.borderStrong}`,
+                }}
+              >
+                <svg width={17} height={17} viewBox="0 0 24 24" fill="none" stroke={removing ? "#f87171" : colors.accentText} strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+                  {removing ? (
+                    <path d="M12 4v9M12 17.5v.5" />
+                  ) : (
+                    <path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6l7-3z" />
+                  )}
+                </svg>
+              </div>
+              <div>
+                <div style={{ fontSize: 15, fontWeight: 700, color: colors.fg }}>{s.device}</div>
+                <div style={{ fontSize: 12.5, color: colors.muted }}>{s.meta}</div>
+              </div>
+              <div style={{ marginLeft: "auto", fontSize: 12.5, fontWeight: 700, color: removing ? "#f87171" : colors.success }}>
+                {removing ? "revoke" : "active"}
+              </div>
+            </div>
+          );
+        })}
+        <div style={{ height: 26, display: "flex", alignItems: "center" }}>
+          {local > revokeAt + 24 && (
+            <Chip color={colors.success} style={{ fontSize: 13 }}>
+              ✓ Suspicious session revoked
+            </Chip>
+          )}
+        </div>
+      </div>
+    </Panel>
+  );
+};

--- a/tools/promo/src/comps/category/demos-heroes.tsx
+++ b/tools/promo/src/comps/category/demos-heroes.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { spring, useCurrentFrame, useVideoConfig } from "remotion";
+import { colors } from "../../theme";
+import { Bar, CheckDot, Chip, clamp01, Panel, Skel, spinnerGlyph } from "./ui";
+
+// Workflow Heroes — miniature stacked product-hero blocks (copy band + surface).
+
+const HeroShell: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div style={{ width: 312, display: "flex", flexDirection: "column", gap: 12 }}>
+    <div style={{ display: "flex", flexDirection: "column", gap: 9 }}>
+      <Skel w={190} h={13} tone="bright" />
+      <Skel w={132} h={9} />
+    </div>
+    {children}
+  </div>
+);
+
+export const AgentOpsHeroDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const agents = [
+    { name: "researcher", period: 120, off: 0 },
+    { name: "planner", period: 120, off: 40 },
+    { name: "executor", period: 120, off: 80 },
+  ];
+  return (
+    <HeroShell>
+      <Panel width={312} glow={0.4}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 11 }}>
+          {agents.map((a) => {
+            const local = (frame + a.off) % a.period;
+            const running = local < 70;
+            return (
+              <div key={a.name} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                <CheckDot p={running ? 0 : 1} size={22} />
+                <div style={{ fontSize: 15, fontWeight: 600, color: colors.fgSecondary, width: 92 }}>
+                  {a.name}
+                </div>
+                {running ? (
+                  <Bar value={local / 70} width={120} />
+                ) : (
+                  <Chip color={colors.success} style={{ padding: "2px 10px", fontSize: 12 }}>
+                    done
+                  </Chip>
+                )}
+                {running && (
+                  <span style={{ color: colors.accentText, fontSize: 14 }}>{spinnerGlyph(frame)}</span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </Panel>
+    </HeroShell>
+  );
+};
+
+export const DeployHeroDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const stages = ["build", "test", "canary", "prod"];
+  const period = 170;
+  const local = frame % period;
+  const per = 36;
+  return (
+    <HeroShell>
+      <Panel width={312}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          {stages.map((s, i) => {
+            const p = clamp01((local - i * per) / 18);
+            const active = local >= i * per && local < (i + 1) * per;
+            return (
+              <React.Fragment key={s}>
+                {i > 0 && (
+                  <div style={{ flex: 1, height: 3, margin: "0 6px", borderRadius: 2, background: colors.surfaceStrong, overflow: "hidden" }}>
+                    <div style={{ width: `${clamp01((local - (i - 1) * per - 18) / 18) * 100}%`, height: "100%", background: colors.accent }} />
+                  </div>
+                )}
+                <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
+                  <CheckDot p={p} size={24} color={i === 3 ? colors.accent : colors.success} />
+                  <div style={{ fontSize: 12, fontWeight: 700, color: active ? colors.fg : colors.muted }}>{s}</div>
+                </div>
+              </React.Fragment>
+            );
+          })}
+        </div>
+        <div style={{ marginTop: 14, display: "flex", gap: 8 }}>
+          <Chip color={colors.success} style={{ fontSize: 12 }}>● healthy</Chip>
+          <Chip style={{ fontSize: 12 }}>v2.4.{Math.floor(frame / period) % 3}</Chip>
+        </div>
+      </Panel>
+    </HeroShell>
+  );
+};
+
+export const LiveDataHeroDemo: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const points = Array.from({ length: 40 }, (_, i) => {
+    const x = i * 7;
+    const y = 40 - (Math.sin(i * 0.45 + frame / 22) * 12 + Math.sin(i * 0.9 - frame / 30) * 7);
+    return `${x},${y}`;
+  }).join(" ");
+  const kpi = 4200 + Math.floor(820 * (0.5 + 0.5 * Math.sin(frame / 45)));
+  const pop = spring({ frame: frame % 45, fps, config: { damping: 20, stiffness: 200 }, durationInFrames: 20 });
+  return (
+    <HeroShell>
+      <Panel width={312} glow={0.3}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 10 }}>
+          <div style={{ fontSize: 30, fontWeight: 800, color: colors.fg, fontVariantNumeric: "tabular-nums" }}>
+            {kpi.toLocaleString("en-US")}
+          </div>
+          <div style={{ fontSize: 13, fontWeight: 700, color: colors.success, transform: `scale(${0.9 + pop * 0.1})` }}>
+            ▲ live
+          </div>
+        </div>
+        <svg width={280} height={54} viewBox="0 0 280 54" style={{ marginTop: 8 }}>
+          <polyline points={points} fill="none" stroke={colors.accent} strokeWidth={2.4} strokeLinejoin="round" />
+        </svg>
+      </Panel>
+    </HeroShell>
+  );
+};

--- a/tools/promo/src/comps/category/index.tsx
+++ b/tools/promo/src/comps/category/index.tsx
@@ -1,0 +1,139 @@
+import { AvatarsDemo, ComposerDemo, KanbanDemo } from "../Showcase";
+import { makeCategory } from "./Layout";
+import { ContourSurfaceDemo, QueueLanesDemo, TopologyFieldDemo } from "./demos-backgrounds";
+import { AgentOpsHeroDemo, DeployHeroDemo, LiveDataHeroDemo } from "./demos-heroes";
+import {
+  EnvSwitcherDemo,
+  LogStreamDemo,
+  PipelineDemo,
+  ResponseStreamDemo,
+  ToolCallDemo,
+} from "./demos-ai-dev";
+import {
+  ApprovalDemo,
+  CommentThreadDemo,
+  DependencyMapDemo,
+  FilterTransitionDemo,
+  KpiMorphDemo,
+  ProjectTimelineDemo,
+  StreamingRowsDemo,
+} from "./demos-collab-data";
+import {
+  CartTransitionDemo,
+  CheckoutProgressDemo,
+  DeliveryStatesDemo,
+  FileUploadPipelineDemo,
+  MultiFileQueueDemo,
+  PasskeyDemo,
+  ProcessingTimelineDemo,
+  SessionSecurityDemo,
+  ThreadExpansionDemo,
+  TwoFactorDemo,
+  TypingPresenceDemo,
+  VariantSelectorDemo,
+} from "./demos-flows";
+
+const KICKER = "Motiq catalog";
+
+// Tile labels are real catalog component names (apps/docs/lib/catalog.ts).
+export const categories = [
+  makeCategory(
+    "motiq-cat-product-backgrounds",
+    { kicker: KICKER, heading: "Product Backgrounds", sub: "Animated canvases that make product surfaces feel alive." },
+    [
+      { label: "Workflow Topology Field", demo: TopologyFieldDemo },
+      { label: "Queue Pulse Lanes", demo: QueueLanesDemo },
+      { label: "Data Contour Surface", demo: ContourSurfaceDemo },
+    ],
+  ),
+  makeCategory(
+    "motiq-cat-workflow-heroes",
+    { kicker: KICKER, heading: "Workflow Heroes", sub: "Full hero blocks with live product surfaces built in." },
+    [
+      { label: "Agent Operations Hero", demo: AgentOpsHeroDemo },
+      { label: "Deployment Control Hero", demo: DeployHeroDemo },
+      { label: "Live Data Command Hero", demo: LiveDataHeroDemo },
+    ],
+  ),
+  makeCategory(
+    "motiq-cat-ai",
+    { kicker: KICKER, heading: "AI interfaces", sub: "Streaming, tool calls and composers for AI products." },
+    [
+      { label: "AI Response Stream", demo: ResponseStreamDemo },
+      { label: "Tool Call Activity", demo: ToolCallDemo },
+      { label: "Prompt Composer", demo: ComposerDemo },
+    ],
+  ),
+  makeCategory(
+    "motiq-cat-developer-tools",
+    { kicker: KICKER, heading: "Developer tools", sub: "Pipelines, logs and environments that feel first-party." },
+    [
+      { label: "Deployment Pipeline", demo: PipelineDemo },
+      { label: "Live Log Stream", demo: LogStreamDemo },
+      { label: "Environment Switcher", demo: EnvSwitcherDemo },
+    ],
+  ),
+  makeCategory(
+    "motiq-cat-collaboration",
+    { kicker: KICKER, heading: "Collaboration", sub: "Presence, comments and approvals for multiplayer apps." },
+    [
+      { label: "Live Presence Stack", demo: AvatarsDemo },
+      { label: "Comment Thread", demo: CommentThreadDemo },
+      { label: "Approval Workflow", demo: ApprovalDemo },
+    ],
+  ),
+  makeCategory(
+    "motiq-cat-data-motion",
+    { kicker: KICKER, heading: "Data motion", sub: "Numbers, rows and filters that move with meaning." },
+    [
+      { label: "KPI Number Morph", demo: KpiMorphDemo },
+      { label: "Streaming Data Rows", demo: StreamingRowsDemo },
+      { label: "Filter Result Transition", demo: FilterTransitionDemo },
+    ],
+  ),
+  makeCategory(
+    "motiq-cat-productivity",
+    { kicker: KICKER, heading: "Productivity", sub: "Boards, dependencies and timelines for work tools." },
+    [
+      { label: "Kanban Card Movement", demo: KanbanDemo },
+      { label: "Task Dependency Map", demo: DependencyMapDemo },
+      { label: "Project Timeline", demo: ProjectTimelineDemo },
+    ],
+  ),
+  makeCategory(
+    "motiq-cat-file-workflows",
+    { kicker: KICKER, heading: "File workflows", sub: "Uploads, queues and processing states users trust." },
+    [
+      { label: "File Upload Pipeline", demo: FileUploadPipelineDemo },
+      { label: "Multi-file Queue", demo: MultiFileQueueDemo },
+      { label: "Processing Timeline", demo: ProcessingTimelineDemo },
+    ],
+  ),
+  makeCategory(
+    "motiq-cat-commerce",
+    { kicker: KICKER, heading: "Commerce", sub: "Variants, carts and checkout flows that convert." },
+    [
+      { label: "Product Variant Selector", demo: VariantSelectorDemo },
+      { label: "Cart Item Transition", demo: CartTransitionDemo },
+      { label: "Checkout Progress", demo: CheckoutProgressDemo },
+    ],
+  ),
+  makeCategory(
+    "motiq-cat-security",
+    { kicker: KICKER, heading: "Security & accounts", sub: "Passkeys, 2FA and session control, beautifully handled." },
+    [
+      { label: "Passkey Setup Flow", demo: PasskeyDemo },
+      { label: "Two-Factor Setup Flow", demo: TwoFactorDemo },
+      { label: "Session Security Center", demo: SessionSecurityDemo },
+    ],
+  ),
+  makeCategory(
+    "motiq-cat-communication",
+    { kicker: KICKER, heading: "Communication", sub: "Delivery states, typing and threads for messaging UIs." },
+    [
+      { label: "Message Delivery States", demo: DeliveryStatesDemo },
+      { label: "Typing and Presence", demo: TypingPresenceDemo },
+      { label: "Thread Expansion", demo: ThreadExpansionDemo },
+    ],
+  ),
+];

--- a/tools/promo/src/comps/category/ui.tsx
+++ b/tools/promo/src/comps/category/ui.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { colors } from "../../theme";
+
+/** Skeleton text bar. */
+export const Skel: React.FC<{
+  w: number;
+  h?: number;
+  tone?: "accent" | "muted" | "bright";
+  style?: React.CSSProperties;
+}> = ({ w, h = 8, tone = "muted", style }) => (
+  <div
+    style={{
+      width: w,
+      height: h,
+      borderRadius: h / 2,
+      background:
+        tone === "accent" ? colors.accentText : tone === "bright" ? colors.fgSecondary : colors.surfaceStrong,
+      opacity: tone === "accent" ? 0.9 : 1,
+      ...style,
+    }}
+  />
+);
+
+/** Panel container used inside tiles. */
+export const Panel: React.FC<{
+  width: number;
+  children: React.ReactNode;
+  glow?: number;
+  style?: React.CSSProperties;
+}> = ({ width, children, glow = 0, style }) => (
+  <div
+    style={{
+      width,
+      borderRadius: 14,
+      border: `1px solid ${colors.borderStrong}`,
+      background: colors.bgElevated,
+      padding: 16,
+      boxShadow: glow > 0 ? `0 0 ${26 * glow}px rgba(79,124,255,${0.35 * glow})` : "0 10px 26px rgba(0,0,0,0.35)",
+      ...style,
+    }}
+  >
+    {children}
+  </div>
+);
+
+/** Small status chip. */
+export const Chip: React.FC<{
+  children: React.ReactNode;
+  color?: string;
+  style?: React.CSSProperties;
+}> = ({ children, color = colors.accentText, style }) => (
+  <div
+    style={{
+      display: "inline-flex",
+      alignItems: "center",
+      gap: 7,
+      padding: "5px 12px",
+      borderRadius: 999,
+      border: `1px solid ${colors.borderStrong}`,
+      background: colors.surface,
+      color,
+      fontSize: 14,
+      fontWeight: 700,
+      ...style,
+    }}
+  >
+    {children}
+  </div>
+);
+
+/** Progress bar with animated fill (0..1). */
+export const Bar: React.FC<{ value: number; width: number; color?: string }> = ({
+  value,
+  width,
+  color = colors.accent,
+}) => (
+  <div
+    style={{
+      width,
+      height: 8,
+      borderRadius: 4,
+      background: colors.surfaceStrong,
+      overflow: "hidden",
+    }}
+  >
+    <div
+      style={{
+        width: `${Math.min(1, Math.max(0, value)) * 100}%`,
+        height: "100%",
+        borderRadius: 4,
+        background: `linear-gradient(90deg, ${color}, ${colors.accentHover})`,
+      }}
+    />
+  </div>
+);
+
+/** Circular check badge with draw progress (0..1). */
+export const CheckDot: React.FC<{ p: number; size?: number; color?: string }> = ({
+  p,
+  size = 26,
+  color = colors.success,
+}) => {
+  const len = 26;
+  const c = Math.min(1, Math.max(0, p));
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        borderRadius: 999,
+        background: c > 0 ? color : colors.surfaceStrong,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        transform: `scale(${0.6 + c * 0.4})`,
+        flexShrink: 0,
+      }}
+    >
+      <svg width={size * 0.55} height={size * 0.55} viewBox="0 0 24 24" fill="none">
+        <path
+          d="M4.5 12.5l5 5L19.5 7"
+          stroke="#0b1020"
+          strokeWidth={3.4}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeDasharray={len}
+          strokeDashoffset={len * (1 - c)}
+        />
+      </svg>
+    </div>
+  );
+};
+
+/** Deterministic spinner glyph. */
+export const spinnerGlyph = (frame: number): string =>
+  ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧"][Math.floor(frame / 4) % 8];
+
+export const clamp01 = (v: number): number => Math.min(1, Math.max(0, v));

--- a/tools/promo/src/comps/social/SquareLoop.tsx
+++ b/tools/promo/src/comps/social/SquareLoop.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { AbsoluteFill, interpolate, useCurrentFrame, useVideoConfig } from "remotion";
+import { z } from "zod";
+import { enter } from "../../helpers";
+import { brand, colors, monoFamily } from "../../theme";
+import { Logomark, Stage } from "../../shared";
+import { ComposerDemo } from "../Showcase";
+import { KpiMorphDemo } from "../category/demos-collab-data";
+import { DeliveryStatesDemo, VariantSelectorDemo } from "../category/demos-flows";
+
+export const squareSchema = z.object({
+  heading: z.string(),
+});
+
+export const squareDefaults: z.infer<typeof squareSchema> = {
+  heading: "Animated React components",
+};
+
+const Cell: React.FC<{ children: React.ReactNode; delay: number }> = ({ children, delay }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const p = enter({ frame, fps, delay });
+  return (
+    <div
+      style={{
+        width: 452,
+        height: 330,
+        borderRadius: 22,
+        border: `1px solid ${colors.border}`,
+        background: colors.surface,
+        boxShadow: "0 18px 50px rgba(0,0,0,0.42)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        overflow: "hidden",
+        opacity: p,
+        transform: `translateY(${interpolate(p, [0, 1], [34, 0])}px)`,
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+export const SquareLoop: React.FC<z.infer<typeof squareSchema>> = ({ heading }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const headIn = enter({ frame, fps, delay: 4 });
+  const cmdIn = enter({ frame, fps, delay: 30 });
+  return (
+    <Stage glowY="8%">
+      <AbsoluteFill style={{ alignItems: "center", paddingTop: 54 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 18, opacity: headIn }}>
+          <Logomark size={54} />
+          <span style={{ fontSize: 46, fontWeight: 800, letterSpacing: -1.5, color: colors.fg }}>
+            {brand.name}
+          </span>
+        </div>
+        <div
+          style={{
+            marginTop: 14,
+            marginBottom: 34,
+            fontSize: 33,
+            fontWeight: 600,
+            color: colors.fgSecondary,
+            opacity: headIn,
+            transform: `translateY(${interpolate(headIn, [0, 1], [16, 0])}px)`,
+          }}
+        >
+          {heading} · free & open source
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 452px)", gap: 24 }}>
+          <Cell delay={14}>
+            <KpiMorphDemo />
+          </Cell>
+          <Cell delay={20}>
+            <VariantSelectorDemo />
+          </Cell>
+          <Cell delay={26}>
+            <ComposerDemo />
+          </Cell>
+          <Cell delay={32}>
+            <DeliveryStatesDemo />
+          </Cell>
+        </div>
+        <div
+          style={{
+            marginTop: 36,
+            padding: "16px 30px",
+            borderRadius: 14,
+            border: `1px solid ${colors.borderStrong}`,
+            background: colors.surface,
+            fontFamily: monoFamily,
+            fontSize: 24,
+            color: colors.fgSecondary,
+            opacity: cmdIn,
+            transform: `translateY(${interpolate(cmdIn, [0, 1], [14, 0])}px)`,
+          }}
+        >
+          <span style={{ color: colors.success }}>❯ </span>
+          npx shadcn add {brand.domain}/r/…
+        </div>
+      </AbsoluteFill>
+    </Stage>
+  );
+};

--- a/tools/promo/src/comps/social/StaticCard.tsx
+++ b/tools/promo/src/comps/social/StaticCard.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { AbsoluteFill } from "remotion";
+import { z } from "zod";
+import { brand, colors, monoFamily } from "../../theme";
+import { Logomark, Stage } from "../../shared";
+import { CatTile } from "../category/Layout";
+import { ToolCallDemo } from "../category/demos-ai-dev";
+import { KpiMorphDemo } from "../category/demos-collab-data";
+
+// Rendered as a still (frame ~140) for X image posts / link cards.
+export const cardSchema = z.object({
+  heading: z.string(),
+  sub: z.string(),
+});
+
+export const cardDefaults: z.infer<typeof cardSchema> = {
+  heading: "Beautiful animated React & shadcn components",
+  sub: "Accessible. Reduced-motion safe. Installed as editable source.",
+};
+
+export const StaticCard: React.FC<z.infer<typeof cardSchema>> = ({ heading, sub }) => (
+  <Stage glowX="26%" glowY="30%">
+    <AbsoluteFill style={{ flexDirection: "row", alignItems: "center", padding: "0 70px", gap: 54 }}>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 28 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+          <Logomark size={58} />
+          <span style={{ fontSize: 44, fontWeight: 800, letterSpacing: -1.4, color: colors.fg }}>
+            {brand.name}
+          </span>
+          <span
+            style={{
+              padding: "6px 14px",
+              borderRadius: 999,
+              border: `1px solid ${colors.borderStrong}`,
+              background: colors.accentSoft,
+              color: colors.accentText,
+              fontSize: 17,
+              fontWeight: 700,
+            }}
+          >
+            Free & open source
+          </span>
+        </div>
+        <div style={{ fontSize: 51, fontWeight: 800, letterSpacing: -1.8, lineHeight: 1.16, color: colors.fg }}>
+          {heading}
+        </div>
+        <div style={{ fontSize: 24, lineHeight: 1.5, color: colors.muted, maxWidth: 520 }}>{sub}</div>
+        <div
+          style={{
+            alignSelf: "flex-start",
+            padding: "14px 24px",
+            borderRadius: 12,
+            border: `1px solid ${colors.borderStrong}`,
+            background: colors.surface,
+            fontFamily: monoFamily,
+            fontSize: 20,
+            color: colors.fgSecondary,
+          }}
+        >
+          <span style={{ color: colors.success }}>❯ </span>
+          npx shadcn add {brand.domain}/r/…
+        </div>
+      </div>
+      <div style={{ position: "relative" }}>
+        <CatTile tile={{ label: "Tool Call Activity", demo: ToolCallDemo }} delay={0} />
+        <div
+          style={{
+            position: "absolute",
+            left: -74,
+            bottom: -26,
+            transform: "scale(0.62)",
+            transformOrigin: "bottom left",
+            filter: "drop-shadow(0 24px 50px rgba(0,0,0,0.6))",
+          }}
+        >
+          <CatTile tile={{ label: "KPI Number Morph", demo: KpiMorphDemo }} delay={0} />
+        </div>
+      </div>
+    </AbsoluteFill>
+  </Stage>
+);

--- a/tools/promo/src/comps/social/Trailer.tsx
+++ b/tools/promo/src/comps/social/Trailer.tsx
@@ -1,0 +1,157 @@
+import React from "react";
+import { AbsoluteFill, interpolate, Sequence, useCurrentFrame, useVideoConfig } from "remotion";
+import { z } from "zod";
+import { enter, pop } from "../../helpers";
+import { brand, colors, monoFamily } from "../../theme";
+import { Badge, Logomark, Stage } from "../../shared";
+import { Install, installDefaults } from "../Install";
+import { Pillars, pillarsDefaults } from "../Pillars";
+import { OpenSource, openSourceDefaults } from "../OpenSource";
+import { categories } from "../category";
+import { TopologyFieldDemo } from "../category/demos-backgrounds";
+
+export const trailerSchema = z.object({
+  hook: z.string(),
+  hookSub: z.string(),
+});
+
+export const trailerDefaults: z.infer<typeof trailerSchema> = {
+  hook: "Stop building UI animation from scratch.",
+  hookSub: "Motiq — animated React & shadcn components, free & open source.",
+};
+
+// X autoplays muted: every scene must carry its message as on-screen text,
+// and the product must be moving from frame 0 (no logo cold-open).
+const HOOK_LEN = 80;
+const MONTAGE_IDS = ["motiq-cat-ai", "motiq-cat-data-motion", "motiq-cat-collaboration", "motiq-cat-commerce"];
+const MONTAGE_LEN = 90;
+const INSTALL_LEN = 200;
+const PILLARS_LEN = 150;
+const OUTRO_LEN = 165;
+
+export const TRAILER_DURATION =
+  HOOK_LEN + MONTAGE_IDS.length * MONTAGE_LEN + INSTALL_LEN + PILLARS_LEN + OUTRO_LEN;
+
+/** Wraps a 1200x675 composition and scales it to the 1280x720 trailer canvas. */
+const Scaled: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <AbsoluteFill>
+    <div style={{ width: 1200, height: 675, position: "relative", transform: "scale(1.0667)", transformOrigin: "top left" }}>
+      {children}
+    </div>
+  </AbsoluteFill>
+);
+
+const HookScene: React.FC<{ hook: string; hookSub: string }> = ({ hook, hookSub }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const words = hook.split(" ");
+  const subIn = enter({ frame, fps, delay: 26 });
+  const markIn = pop({ frame, fps, delay: 2 });
+  return (
+    <Stage glowY="42%">
+      <AbsoluteFill style={{ alignItems: "center", justifyContent: "center", opacity: 0.4 }}>
+        <div style={{ transform: "scale(2.6)" }}>
+          <TopologyFieldDemo />
+        </div>
+      </AbsoluteFill>
+      <AbsoluteFill style={{ alignItems: "center", justifyContent: "center", flexDirection: "column", gap: 34, padding: "0 120px" }}>
+        <div style={{ transform: `scale(${markIn})` }}>
+          <Logomark size={72} />
+        </div>
+        <div style={{ textAlign: "center", fontSize: 66, fontWeight: 800, letterSpacing: -2, lineHeight: 1.15, color: colors.fg }}>
+          {words.map((w, i) => {
+            const p = enter({ frame, fps, delay: 6 + i * 3 });
+            return (
+              <span
+                key={i}
+                style={{
+                  display: "inline-block",
+                  marginRight: 16,
+                  opacity: p,
+                  transform: `translateY(${interpolate(p, [0, 1], [30, 0])}px)`,
+                }}
+              >
+                {w}
+              </span>
+            );
+          })}
+        </div>
+        <div
+          style={{
+            fontSize: 27,
+            fontWeight: 500,
+            color: colors.fgSecondary,
+            opacity: subIn,
+            transform: `translateY(${interpolate(subIn, [0, 1], [16, 0])}px)`,
+          }}
+        >
+          {hookSub}
+        </div>
+      </AbsoluteFill>
+    </Stage>
+  );
+};
+
+const OutroScene: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const cmdIn = enter({ frame, fps, delay: 70 });
+  return (
+    <AbsoluteFill>
+      <Scaled>
+        <OpenSource {...openSourceDefaults} />
+      </Scaled>
+      <AbsoluteFill style={{ alignItems: "center", justifyContent: "flex-end", paddingBottom: 34 }}>
+        <div
+          style={{
+            fontFamily: monoFamily,
+            fontSize: 20,
+            color: colors.muted,
+            opacity: cmdIn,
+          }}
+        >
+          {brand.github}
+        </div>
+      </AbsoluteFill>
+    </AbsoluteFill>
+  );
+};
+
+export const Trailer: React.FC<z.infer<typeof trailerSchema>> = ({ hook, hookSub }) => {
+  const montage = MONTAGE_IDS.map((id) => categories.find((c) => c.id === id)).filter(
+    (c): c is NonNullable<typeof c> => c !== undefined,
+  );
+  let at = 0;
+  const seq = (len: number) => {
+    const from = at;
+    at += len;
+    return from;
+  };
+  return (
+    <AbsoluteFill style={{ backgroundColor: colors.bg }}>
+      <Sequence from={seq(HOOK_LEN)} durationInFrames={HOOK_LEN}>
+        <HookScene hook={hook} hookSub={hookSub} />
+      </Sequence>
+      {montage.map((cat) => (
+        <Sequence key={cat.id} from={seq(MONTAGE_LEN)} durationInFrames={MONTAGE_LEN}>
+          <Scaled>
+            <cat.component {...cat.defaults} />
+          </Scaled>
+        </Sequence>
+      ))}
+      <Sequence from={seq(INSTALL_LEN)} durationInFrames={INSTALL_LEN}>
+        <Scaled>
+          <Install {...installDefaults} />
+        </Scaled>
+      </Sequence>
+      <Sequence from={seq(PILLARS_LEN)} durationInFrames={PILLARS_LEN}>
+        <Scaled>
+          <Pillars {...pillarsDefaults} />
+        </Scaled>
+      </Sequence>
+      <Sequence from={seq(OUTRO_LEN)} durationInFrames={OUTRO_LEN}>
+        <OutroScene />
+      </Sequence>
+    </AbsoluteFill>
+  );
+};

--- a/tools/promo/src/comps/social/Vertical.tsx
+++ b/tools/promo/src/comps/social/Vertical.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+import { AbsoluteFill, interpolate, useCurrentFrame, useVideoConfig } from "remotion";
+import { z } from "zod";
+import { enter } from "../../helpers";
+import { brand, colors, monoFamily } from "../../theme";
+import { Badge, Logomark, Stage } from "../../shared";
+import { ResponseStreamDemo } from "../category/demos-ai-dev";
+import { StreamingRowsDemo } from "../category/demos-collab-data";
+import { CheckoutProgressDemo } from "../category/demos-flows";
+
+export const verticalSchema = z.object({
+  hook: z.string(),
+});
+
+export const verticalDefaults: z.infer<typeof verticalSchema> = {
+  hook: "Stop building UI animation from scratch",
+};
+
+const Card: React.FC<{ label: string; children: React.ReactNode; delay: number }> = ({
+  label,
+  children,
+  delay,
+}) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const p = enter({ frame, fps, delay });
+  return (
+    <div
+      style={{
+        width: 720,
+        height: 400,
+        borderRadius: 26,
+        border: `1px solid ${colors.border}`,
+        background: colors.surface,
+        boxShadow: "0 22px 60px rgba(0,0,0,0.45)",
+        overflow: "hidden",
+        position: "relative",
+        opacity: p,
+        transform: `translateY(${interpolate(p, [0, 1], [46, 0])}px) scale(${interpolate(p, [0, 1], [0.95, 1])})`,
+      }}
+    >
+      <div style={{ height: 336, display: "flex", alignItems: "center", justifyContent: "center", transform: "scale(1.12)" }}>
+        {children}
+      </div>
+      <div
+        style={{
+          position: "absolute",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          height: 64,
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          padding: "0 26px",
+          fontSize: 22,
+          fontWeight: 600,
+          color: colors.fgSecondary,
+          borderTop: `1px solid ${colors.border}`,
+          background: colors.bgElevated,
+        }}
+      >
+        <span style={{ width: 10, height: 10, borderRadius: 999, background: colors.accent, boxShadow: `0 0 12px ${colors.accent}` }} />
+        {label}
+      </div>
+    </div>
+  );
+};
+
+export const Vertical: React.FC<z.infer<typeof verticalSchema>> = ({ hook }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const headIn = enter({ frame, fps, delay: 4 });
+  const ctaIn = enter({ frame, fps, delay: 44 });
+  return (
+    <Stage glowY="6%">
+      <AbsoluteFill style={{ alignItems: "center", paddingTop: 90 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 16, opacity: headIn }}>
+          <Logomark size={52} />
+          <span style={{ fontSize: 42, fontWeight: 800, letterSpacing: -1.2, color: colors.fg }}>{brand.name}</span>
+        </div>
+        <div
+          style={{
+            marginTop: 26,
+            marginBottom: 40,
+            maxWidth: 860,
+            textAlign: "center",
+            fontSize: 62,
+            fontWeight: 800,
+            letterSpacing: -2,
+            lineHeight: 1.14,
+            color: colors.fg,
+            opacity: headIn,
+            transform: `translateY(${interpolate(headIn, [0, 1], [26, 0])}px)`,
+          }}
+        >
+          {hook}
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 30 }}>
+          <Card label="AI Response Stream" delay={16}>
+            <ResponseStreamDemo />
+          </Card>
+          <Card label="Streaming Data Rows" delay={26}>
+            <StreamingRowsDemo />
+          </Card>
+          <Card label="Checkout Progress" delay={36}>
+            <CheckoutProgressDemo />
+          </Card>
+        </div>
+        <div style={{ marginTop: 44, display: "flex", flexDirection: "column", alignItems: "center", gap: 22, opacity: ctaIn, transform: `translateY(${interpolate(ctaIn, [0, 1], [18, 0])}px)` }}>
+          <div
+            style={{
+              padding: "18px 34px",
+              borderRadius: 16,
+              border: `1px solid ${colors.borderStrong}`,
+              background: colors.surface,
+              fontFamily: monoFamily,
+              fontSize: 27,
+              color: colors.fgSecondary,
+            }}
+          >
+            <span style={{ color: colors.success }}>❯ </span>
+            npx shadcn add {brand.domain}/r/…
+          </div>
+          <Badge delay={50}>60+ components & blocks · free & open source · {brand.domain}</Badge>
+        </div>
+      </AbsoluteFill>
+    </Stage>
+  );
+};

--- a/tools/promo/src/helpers.ts
+++ b/tools/promo/src/helpers.ts
@@ -1,0 +1,46 @@
+import { interpolate, spring } from "remotion";
+
+// Deterministic PRNG (mulberry32) so particle layouts are stable per seed —
+// Math.random() is banned in render paths.
+export const seededRandom = (seed: number): (() => number) => {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+type SpringIn = {
+  frame: number;
+  fps: number;
+  delay?: number;
+  durationInFrames?: number;
+};
+
+/** Settling spring for entrances (0 → 1). */
+export const enter = ({ frame, fps, delay = 0, durationInFrames }: SpringIn): number =>
+  spring({
+    frame: frame - delay,
+    fps,
+    config: { damping: 26, stiffness: 190, mass: 0.9 },
+    durationInFrames,
+  });
+
+/** Snappier spring for pops and icons. */
+export const pop = ({ frame, fps, delay = 0, durationInFrames }: SpringIn): number =>
+  spring({
+    frame: frame - delay,
+    fps,
+    config: { damping: 16, stiffness: 260, mass: 0.7 },
+    durationInFrames,
+  });
+
+/** Clamped linear fade helper. */
+export const fade = (frame: number, from: number, to: number): number =>
+  interpolate(frame, [from, to], [0, 1], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  });

--- a/tools/promo/src/index.ts
+++ b/tools/promo/src/index.ts
@@ -1,0 +1,4 @@
+import { registerRoot } from "remotion";
+import { Root } from "./Root";
+
+registerRoot(Root);

--- a/tools/promo/src/shared.tsx
+++ b/tools/promo/src/shared.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { AbsoluteFill, interpolate, useCurrentFrame, useVideoConfig } from "remotion";
+import { colors, fontFamily } from "./theme";
+import { enter } from "./helpers";
+
+/** Dark stage: base color, faint blueprint grid, and a slow-breathing accent glow. */
+export const Stage: React.FC<{ children: React.ReactNode; glowX?: string; glowY?: string }> = ({
+  children,
+  glowX = "50%",
+  glowY = "18%",
+}) => {
+  const frame = useCurrentFrame();
+  const { fps, durationInFrames } = useVideoConfig();
+  // Full sine cycles over the composition so the loop point is seamless.
+  const cycles = Math.max(1, Math.round(durationInFrames / (fps * 6)));
+  const breathe = Math.sin((frame / durationInFrames) * Math.PI * 2 * cycles);
+  const glowOpacity = 0.5 + breathe * 0.12;
+  return (
+    <AbsoluteFill style={{ backgroundColor: colors.bg, fontFamily, overflow: "hidden" }}>
+      <AbsoluteFill
+        style={{
+          backgroundImage: `linear-gradient(${colors.border} 1px, transparent 1px), linear-gradient(90deg, ${colors.border} 1px, transparent 1px)`,
+          backgroundSize: "48px 48px",
+          opacity: 0.16,
+          maskImage: "radial-gradient(ellipse 90% 80% at 50% 40%, black 30%, transparent 78%)",
+          WebkitMaskImage: "radial-gradient(ellipse 90% 80% at 50% 40%, black 30%, transparent 78%)",
+        }}
+      />
+      <AbsoluteFill
+        style={{
+          background: `radial-gradient(ellipse 55% 42% at ${glowX} ${glowY}, rgba(79,124,255,0.22), transparent 70%)`,
+          opacity: glowOpacity,
+        }}
+      />
+      {children}
+    </AbsoluteFill>
+  );
+};
+
+/** Motiq logomark: rounded square with a motion-trail "M" pulse. */
+export const Logomark: React.FC<{ size?: number }> = ({ size = 56 }) => (
+  <div
+    style={{
+      width: size,
+      height: size,
+      borderRadius: size * 0.28,
+      background: `linear-gradient(135deg, ${colors.accent}, #315fea)`,
+      boxShadow: `0 0 ${size * 0.6}px rgba(79,124,255,0.45), inset 0 1px 0 rgba(255,255,255,0.25)`,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+    }}
+  >
+    <svg width={size * 0.55} height={size * 0.55} viewBox="0 0 24 24" fill="none">
+      <path
+        d="M4 18V7.5L9.5 14L15 7.5V18"
+        stroke="#fff"
+        strokeWidth={2.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx={19.5} cy={16.5} r={1.8} fill="#fff" />
+    </svg>
+  </div>
+);
+
+/** Small pill badge used for kickers ("60+ components", "Free & open source"…). */
+export const Badge: React.FC<{ children: React.ReactNode; delay?: number }> = ({
+  children,
+  delay = 0,
+}) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const p = enter({ frame, fps, delay });
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "8px 18px",
+        borderRadius: 999,
+        border: `1px solid ${colors.borderStrong}`,
+        background: colors.accentSoft,
+        color: colors.accentText,
+        fontSize: 20,
+        fontWeight: 600,
+        letterSpacing: 0.3,
+        opacity: p,
+        transform: `translateY(${interpolate(p, [0, 1], [14, 0])}px)`,
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+/** macOS-style window chrome for terminal / code panels. */
+export const Window: React.FC<{
+  title: string;
+  width: number;
+  children: React.ReactNode;
+  style?: React.CSSProperties;
+}> = ({ title, width, children, style }) => (
+  <div
+    style={{
+      width,
+      borderRadius: 16,
+      border: `1px solid ${colors.borderStrong}`,
+      background: colors.bgElevated,
+      boxShadow: "0 30px 80px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.03) inset",
+      overflow: "hidden",
+      ...style,
+    }}
+  >
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "14px 18px",
+        borderBottom: `1px solid ${colors.border}`,
+        background: colors.surface,
+      }}
+    >
+      {["#ff5f57", "#febc2e", "#28c840"].map((c) => (
+        <div key={c} style={{ width: 13, height: 13, borderRadius: 999, background: c }} />
+      ))}
+      <div
+        style={{
+          flex: 1,
+          textAlign: "center",
+          color: colors.muted,
+          fontSize: 16,
+          fontWeight: 500,
+          marginRight: 55,
+        }}
+      >
+        {title}
+      </div>
+    </div>
+    {children}
+  </div>
+);

--- a/tools/promo/src/theme.ts
+++ b/tools/promo/src/theme.ts
@@ -1,0 +1,32 @@
+// Brand values mirrored from packages/tokens/styles.css (dark theme) and
+// product.config.json. Kept as constants because this internal tool is
+// intentionally isolated from the workspace packages.
+
+export const brand = {
+  name: "Motiq",
+  tagline: "Animated React & shadcn components, installable as editable source.",
+  domain: "motiq.dev",
+  github: "github.com/RMahammad/motiq",
+} as const;
+
+export const colors = {
+  bg: "#080c14",
+  bgElevated: "#0d1420",
+  surface: "#111827",
+  surfaceRaised: "#192337",
+  surfaceStrong: "#243249",
+  border: "#263449",
+  borderStrong: "#354863",
+  fg: "#f8fafc",
+  fgSecondary: "#cbd5e1",
+  muted: "#9caabd",
+  accent: "#4f7cff",
+  accentHover: "#6f91ff",
+  accentText: "#7f9fff",
+  accentSoft: "rgba(79, 124, 255, 0.14)",
+  success: "#34d399",
+  amber: "#fbbf24",
+} as const;
+
+export const fontFamily = "'Inter', sans-serif";
+export const monoFamily = "'JetBrains Mono', monospace";

--- a/tools/promo/tsconfig.json
+++ b/tools/promo/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "lib": ["DOM", "ES2022"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Internal marketing tool that renders the Motiq promo kit with Remotion: 5 general GIFs, 11 category showcases, and a social kit (16:9 trailer, 1:1 loop, 9:16 vertical, static card). Isolated from the workspace (own npm install, excluded from ESLint); the @scope/remotion product package is untouched. Rendered media is gitignored and regenerable via npm run render / render:social; channel captions live in assets/promo/README.md.

Covered by Remotion's free tier (local, individual marketing use) — license note recorded in docs/07-remotion-strategy.md.

## What does this PR do?

Briefly describe the change and the motivation.

## Related issues

Closes #

## Checklist

- [ ] Focused change (one component or concern)
- [ ] Accessible — keyboard, focus, screen-reader semantics, contrast (WCAG 2.2 AA)
- [ ] Respects `prefers-reduced-motion`; continuous animation pauses offscreen
- [ ] RSC-safe (`"use client"` only where needed)
- [ ] Uses semantic tokens (no unnecessary hardcoded values)
- [ ] Tests added/updated (unit / SSR / reduced-motion / axe)
- [ ] Preview + docs updated; registry rebuilt if a component changed
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm docs:check` pass
