### PR TITLE
Add Motiq promo-render tool and consolidate marketing assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,10 +69,12 @@ docs/59-homepage-art-direction-pass.md
 # Remotion render intermediates (internal promo tool)
 tools/promo/out/
 
-# Rendered promo media — regenerable via tools/promo (npm run render / render:social).
-# Kept out of git history to avoid binary bloat; the channel doc + captions
-# (assets/promo/README.md) and the tool source stay tracked. Distribute the
-# rendered files via a GitHub Release or upload them natively when posting.
-assets/promo/*.gif
-assets/promo/*.mp4
-assets/promo/*.png
+# Rendered marketing media under assets/ — regenerable via tools/promo
+# (npm run render / render:social) and assets/launch/tools. Kept out of git
+# history to avoid binary bloat; the combined channel doc (assets/README.md)
+# and the re-record tool source stay tracked. Distribute the rendered files
+# via a GitHub Release or upload them natively when posting.
+assets/**/*.gif
+assets/**/*.mp4
+assets/**/*.png
+assets/**/*.jpg

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,10 +1,19 @@
-# Promo asset kit
+# Motiq marketing assets
 
-Rendered by [`tools/promo/`](../../tools/promo/README.md) (`npm run render` for GIFs, `npm run render:social` for this kit). Channel rules, timing, and the full launch sequence live in [`LAUNCH.md`](../../LAUNCH.md) — this file only maps assets to channels and gives paste-ready captions.
+Everything for promoting Motiq lives here. Two kits, one place:
 
-All claims match LAUNCH.md's fact sheet (56 components + 8 blocks → "60+ components & blocks"; free & open source; shadcn-registry install). Never add user counts or download numbers to a caption.
+- **[`promo/`](promo/)** — Remotion-rendered promo & social kit (this is the primary set). Source: [`tools/promo/`](../tools/promo/README.md).
+- **[`launch/`](launch/)** — Playwright-captured launch clips + social preview image, recorded from the live docs previews. Source: [`launch/tools/`](launch/tools/).
 
-## Which asset where
+The rendered media (`*.gif`, `*.mp4`, `*.png`, `*.jpg`) is **gitignored** — it's regenerable from the tools and would bloat git history. This README, the captions, and the re-record tool source stay tracked. Distribute the rendered files via a GitHub Release or upload them natively when posting.
+
+Channel rules, timing, and the full launch sequence live in [`LAUNCH.md`](../LAUNCH.md); this file maps assets to channels and gives paste-ready captions. **All claims match LAUNCH.md's fact sheet** (56 components + 8 blocks → "60+ components & blocks"; free & open source; shadcn-registry install). Never add user counts or download numbers to a caption.
+
+---
+
+## `promo/` — Remotion promo & social kit
+
+Rendered by [`tools/promo/`](../tools/promo/README.md): `npm run render` (GIFs) and `npm run render:social` (trailer/square/vertical/card).
 
 | Asset | Format | Built for | Notes |
 | --- | --- | --- | --- |
@@ -16,9 +25,30 @@ All claims match LAUNCH.md's fact sheet (56 components + 8 blocks → "60+ compo
 | `motiq-cat-*.gif` (11) | 16:9 GIFs | Drip engine: one category per post; docs pages; Reddit niche subs | Match the sub: `motiq-cat-ai` → AI-adjacent subs, `motiq-cat-developer-tools` → r/devtools etc. |
 | `tools/promo/out/*.mp4` | source MP4s of every GIF | Anywhere video beats GIF | X re-encodes GIFs to video anyway — prefer the MP4. |
 
+## `launch/` — Playwright launch capture kit
+
+Generated 2026-07-18 from the live docs previews (dark theme, real components, scripted interactions, demo control bars hidden).
+
+- `gif/` — looping GIFs (seamless except the log stream, a continuous feed):
+  - `ai-response-stream.gif` — restart → token stream → citations/code → complete
+  - `kpi-number-morph.gif` — 4 snapshot updates, per-digit morphs, back to start
+  - `deployment-pipeline.gif` — all passed → inject test failure → halt → retry → passed
+  - `live-presence-stack.gif` — join/leave choreography, returns to initial roster
+  - `live-log-stream.gif` — scripted deploy feed
+- `mp4/` — same clips as H.264 MP4 (use these on X — it compresses GIFs badly)
+- `social-preview.jpg` — 2560×1280 GitHub social preview (**upload this one**: GitHub's limit is 1MB; the PNG is over). Repo Settings → General → Social preview.
+- `social-preview.png` — lossless version (Reddit fallback, Product Hunt gallery source)
+- `tools/` — re-record pipeline for the drip engine:
+  1. Start the docs dev server on :3000.
+  2. `node tools/capture.mjs` (optionally append slugs to re-record a subset). Add a new target entry with its click choreography to record a new component.
+  3. `zsh tools/convert.sh` → writes `gif/` + `mp4/` here.
+  4. Social card: edit `tools/social-card.html`, render with `node tools/render-card.mjs` (both reference the scratchpad frame dir — update paths when re-running in a new session).
+
+---
+
 ## Paste-ready captions
 
-**X — launch post (attach `motiq-trailer.mp4`):**
+**X — launch post (attach `promo/motiq-trailer.mp4`):**
 > Stop building UI animation from scratch.
 >
 > I built Motiq — 60+ animated React & shadcn components and blocks. Accessible, reduced-motion safe, RSC-safe, installed as editable source into your repo.
@@ -27,7 +57,7 @@ All claims match LAUNCH.md's fact sheet (56 components + 8 blocks → "60+ compo
 >
 > motiq.dev
 
-**X — drip post (attach one `motiq-cat-*.gif`'s MP4, rotate categories, 2–3×/week):**
+**X — drip post (attach one `promo/motiq-cat-*.gif`'s MP4, rotate categories, 2–3×/week):**
 > [Category] components for [use case], animated and production-ready.
 >
 > `npx shadcn add https://motiq.dev/r/<component>`
@@ -45,7 +75,7 @@ All claims match LAUNCH.md's fact sheet (56 components + 8 blocks → "60+ compo
 
 **r/webdev:** Showoff Saturday megathread only — same copy, shorter.
 
-**LinkedIn (attach trailer or square loop):**
+**LinkedIn (attach the trailer or square loop):**
 > Shipping polished UI motion is still weirdly hard: engineers hand-roll animations, then accessibility and reduced-motion get skipped under deadline. I built Motiq to fix that — 60+ production-ready animated React components, free and open source, installed as editable source through the shadcn registry. motiq.dev
 
 ## Rules of thumb (from research — sources in LAUNCH.md)

--- a/assets/launch/tools/capture.mjs
+++ b/assets/launch/tools/capture.mjs
@@ -1,0 +1,241 @@
+// Capture looping demo videos of Motiq previews with Playwright, for GIF/MP4 conversion.
+import { createRequire } from "module";
+import { mkdirSync, renameSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const require = createRequire("/Users/mahammadrustamov/Desktop/remotion-library/package.json");
+const { chromium } = require("playwright");
+
+const BASE = "http://localhost:3000/components/";
+const OUT = process.argv[2] || "/private/tmp/claude-501/-Users-mahammadrustamov-Desktop-remotion-library/dc437483-f277-47cb-a296-55d119bbcc01/scratchpad/captures";
+mkdirSync(OUT, { recursive: true });
+
+const VIEW = { width: 1600, height: 1300 };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Per-target choreography. Each returns to its initial visual state so the GIF loops seamlessly.
+const TARGETS = [
+  {
+    slug: "ai-response-stream",
+    // Auto-streams on mount. Wait for completion during setup, then: hold complete
+    // 0.8s -> restart -> stream to complete -> hold 1.6s. Seam: complete -> complete.
+    run: async (page, api) => {
+      await api.waitUntil(page, () => {
+        const b = [...document.querySelectorAll("button")].find((x) => x.textContent.trim() === "Stop");
+        return b && b.disabled;
+      }, 30000);
+      await sleep(400);
+      const t0 = await api.mark();
+      await sleep(800);
+      await api.click(page, "Start stream", "Restart");
+      await api.waitUntil(page, () => {
+        const b = [...document.querySelectorAll("button")].find((x) => x.textContent.trim() === "Stop");
+        return b && b.disabled;
+      }, 30000);
+      await sleep(1600);
+      return t0;
+    },
+  },
+  {
+    slug: "kpi-number-morph",
+    // 4 snapshots cycle: 4 clicks returns to snapshot 0. Seam: s0 -> s0.
+    run: async (page, api) => {
+      const t0 = await api.mark();
+      await sleep(1000);
+      for (let k = 0; k < 4; k++) {
+        await api.click(page, "Simulate update");
+        await sleep(2200);
+      }
+      await sleep(600);
+      return t0;
+    },
+  },
+  {
+    slug: "deployment-pipeline",
+    // Demo mounts settled on a Test failure. Setup: retry to reach all-passed.
+    // Loop: passed (hold) -> inject failure -> halts at Test -> retry -> passed (hold).
+    run: async (page, api) => {
+      const has = (s) => `document.querySelector("#preview").textContent.includes(${JSON.stringify(s)})`;
+      await api.waitUntil(page, has("Halted at Test"), 30000);
+      await api.click(page, "Retry Test", "Retry");
+      await api.waitUntil(page, has("All stages passed"), 30000);
+      await sleep(500);
+      const t0 = await api.mark();
+      await sleep(1000);
+      await api.click(page, "Inject test failure");
+      await api.waitUntil(page, has("Halted at Test"), 30000);
+      await sleep(1400);
+      await api.click(page, "Retry Test", "Retry");
+      await api.waitUntil(page, has("All stages passed"), 30000);
+      await sleep(1700);
+      return t0;
+    },
+  },
+  {
+    slug: "live-presence-stack",
+    // Starts with 4 users; join/leave choreography nets back to the same 4. Seam clean.
+    run: async (page, api) => {
+      const t0 = await api.mark();
+      await sleep(900);
+      const seq = ["Join", "Join", "Leave", "Join", "Leave", "Leave"];
+      for (const label of seq) {
+        await api.click(page, label);
+        await sleep(1500);
+      }
+      await sleep(500);
+      return t0;
+    },
+  },
+  {
+    slug: "live-log-stream",
+    // Continuous scripted feed (1200ms cadence); record a stretch, cut between appends.
+    run: async (page, api) => {
+      const t0 = await api.mark();
+      await sleep(12000);
+      return t0;
+    },
+  },
+];
+
+let CURRENT = { page: null, sel: null };
+const api = {
+  // Freeze the stage at its settled height so later state changes can't shrink it
+  // and pull unrelated page content into the crop band.
+  mark: async () => {
+    const { page, sel } = CURRENT;
+    await page.evaluate((s) => {
+      const inner = document.querySelector(s).firstElementChild.firstElementChild;
+      inner.style.minHeight = inner.getBoundingClientRect().height + "px";
+      inner.scrollIntoView({ block: "center", behavior: "instant" });
+    }, sel);
+    return Date.now();
+  },
+  click: async (page, ...labels) => {
+    const ok = await page.evaluate((lbls) => {
+      const btns = [...document.querySelectorAll("#preview button")];
+      for (const l of lbls) {
+        const b = btns.find((x) => x.textContent.trim().includes(l) && !x.disabled);
+        if (b) { b.click(); return l; }
+      }
+      return null;
+    }, labels);
+    if (!ok) throw new Error(`no clickable button among: ${labels.join(", ")}`);
+  },
+  waitUntil: async (page, fn, timeout) => {
+    await page.waitForFunction(fn, null, { timeout });
+  },
+};
+
+const only = process.argv.slice(3);
+const browser = await chromium.launch();
+let report = {};
+try { report = JSON.parse((await import("fs")).readFileSync(join(OUT, "report.json"), "utf8")); } catch {}
+
+for (const t of TARGETS) {
+  if (only.length && !only.includes(t.slug)) continue;
+  const ctx = await browser.newContext({
+    viewport: VIEW,
+    colorScheme: "dark",
+    recordVideo: { dir: OUT, size: VIEW },
+    deviceScaleFactor: 1,
+  });
+  const page = await ctx.newPage();
+  const tCtx = Date.now();
+  await page.goto(BASE + t.slug, { waitUntil: "networkidle" });
+  const stageSel = `#${t.slug}-panel-preview`;
+  CURRENT = { page, sel: stageSel };
+  await page.waitForSelector(stageSel);
+  await page.evaluate(() => document.fonts.ready);
+
+  // Hide demo control bars (buttons stay JS-clickable) and center the stage.
+  await page.evaluate((sel) => {
+    const stage = document.querySelector(sel);
+    // Demo control bars are flex-wrap bg-secondary rows sitting as direct children of
+    // the preview's max-w wrapper. Component internals (e.g. the pipeline's console
+    // card) also use bg-secondary + buttons, so scope tightly.
+    for (const w of stage.querySelectorAll('[class*="max-w-"]')) {
+      for (const c of w.children) {
+        const cls = String(c.className);
+        if (cls.includes("flex-wrap") && cls.includes("bg-[var(--color-bg-secondary)]") && c.querySelector("button")) {
+          c.style.display = "none";
+        }
+        if (c.tagName === "P" && c.textContent.includes("Demo data")) c.style.display = "none";
+      }
+      for (const el of w.querySelectorAll("p,div,span")) {
+        const t = el.textContent.trim();
+        if (t.length < 80 && /Demo data|Demo stream|fictional|no live model|illustrative/i.test(t)) {
+          el.style.display = "none";
+        }
+      }
+    }
+    stage.scrollIntoView({ block: "center", behavior: "instant" });
+  }, stageSel);
+  await sleep(300);
+
+  // Track the union bounding box of visible stage content over the whole recording,
+  // so growing content (streams, expanding panels) never escapes the crop.
+  const sampler = setInterval(() => {
+    page.evaluate((sel) => {
+      const stage = document.querySelector(sel);
+      if (!stage) return;
+      const box = { l: Infinity, t: Infinity, r: -Infinity, b: -Infinity };
+      // Preview modules constrain themselves with max-w-* wrappers; union those to hug
+      // the component instead of the full-width centering rows around it.
+      const inner = stage.firstElementChild?.firstElementChild ?? stage;
+      const cands = [...inner.querySelectorAll('[class*="max-w-"]')];
+      const add = (el) => {
+        const r = el.getBoundingClientRect();
+        if (r.width > 40 && r.height > 20) {
+          box.l = Math.min(box.l, r.left); box.t = Math.min(box.t, r.top);
+          box.r = Math.max(box.r, r.right); box.b = Math.max(box.b, r.bottom);
+        }
+      };
+      if (cands.length) cands.forEach(add);
+      else for (const c of inner.children) {
+        const cs = getComputedStyle(c);
+        if (cs.position !== "absolute" && cs.display !== "none") add(c);
+      }
+      const w = window;
+      w.__cropUnion = w.__cropUnion || { l: Infinity, t: Infinity, r: -Infinity, b: -Infinity };
+      const u = w.__cropUnion;
+      u.l = Math.min(u.l, box.l); u.t = Math.min(u.t, box.t);
+      u.r = Math.max(u.r, box.r); u.b = Math.max(u.b, box.b);
+    }, stageSel).catch(() => {});
+  }, 400);
+
+  let t0;
+  try {
+    t0 = await t.run(page, api);
+  } finally {
+    clearInterval(sampler);
+  }
+  const tEnd = Date.now();
+  const union = await page.evaluate(() => window.__cropUnion);
+  const stageRect = await page.evaluate((s) => {
+    const inner = document.querySelector(s).firstElementChild.firstElementChild;
+    return inner.getBoundingClientRect().toJSON();
+  }, stageSel);
+  union.l = Math.max(union.l, stageRect.left); union.t = Math.max(union.t, stageRect.top);
+  union.r = Math.min(union.r, stageRect.right); union.b = Math.min(union.b, stageRect.bottom);
+  const video = page.video();
+  await ctx.close();
+  const raw = await video.path();
+  const dest = join(OUT, `${t.slug}.webm`);
+  renameSync(raw, dest);
+
+  const PAD = 26;
+  // Pad around the content, but never past the stage surface (avoids slivers of
+  // the docs page leaking in at the edges).
+  const L = Math.max(0, Math.max(union.l - PAD, stageRect.left + 2));
+  const T = Math.max(0, Math.max(union.t - PAD, stageRect.top + 2));
+  const R = Math.min(VIEW.width, Math.min(union.r + PAD, stageRect.right - 2));
+  const B = Math.min(VIEW.height, Math.min(union.b + PAD, stageRect.bottom - 2));
+  const crop = { x: Math.floor(L), y: Math.floor(T), w: Math.ceil(R - L) & ~1, h: Math.ceil(B - T) & ~1 };
+  report[t.slug] = { crop, trimStart: (t0 - tCtx) / 1000, duration: (tEnd - t0) / 1000 };
+  console.log(t.slug, JSON.stringify(report[t.slug]));
+  writeFileSync(join(OUT, "report.json"), JSON.stringify(report, null, 2));
+}
+
+await browser.close();
+writeFileSync(join(OUT, "report.json"), JSON.stringify(report, null, 2));
+console.log("done");

--- a/assets/launch/tools/convert.sh
+++ b/assets/launch/tools/convert.sh
@@ -1,0 +1,20 @@
+#!/bin/zsh
+set -e
+DIR=captures
+OUT=/Users/mahammadrustamov/Desktop/remotion-library/assets/launch
+mkdir -p $OUT/gif $OUT/mp4
+for slug in $(node -e "const r=require('./captures/report.json');console.log(Object.keys(r).join(' '))"); do
+  eval $(node -e "
+    const r=require('./captures/report.json')['$slug'];
+    console.log(\`SS=\${r.trimStart} DUR=\${r.duration} CW=\${r.crop.w} CH=\${r.crop.h} CX=\${r.crop.x} CY=\${r.crop.y}\`)")
+  echo "== $slug ss=$SS dur=$DUR crop=${CW}x${CH}+${CX}+${CY}"
+  ffmpeg -hide_banner -loglevel error -y -ss $SS -t $DUR -i $DIR/$slug.webm \
+    -vf "crop=${CW}:${CH}:${CX}:${CY}" -r 30 -c:v libx264 -preset slow -crf 19 -pix_fmt yuv420p -movflags +faststart \
+    $OUT/mp4/$slug.mp4
+  ffmpeg -hide_banner -loglevel error -y -ss $SS -t $DUR -i $DIR/$slug.webm \
+    -vf "crop=${CW}:${CH}:${CX}:${CY},fps=16,palettegen=stats_mode=diff:max_colors=200" palette-$slug.png
+  ffmpeg -hide_banner -loglevel error -y -ss $SS -t $DUR -i $DIR/$slug.webm -i palette-$slug.png \
+    -lavfi "crop=${CW}:${CH}:${CX}:${CY},fps=16 [x]; [x][1:v] paletteuse=dither=sierra2_4a:diff_mode=rectangle" \
+    -loop 0 $OUT/gif/$slug.gif
+done
+ls -la $OUT/gif $OUT/mp4

--- a/assets/launch/tools/render-card.mjs
+++ b/assets/launch/tools/render-card.mjs
@@ -1,0 +1,11 @@
+import { createRequire } from "module";
+const require = createRequire("/Users/mahammadrustamov/Desktop/remotion-library/package.json");
+const { chromium } = require("playwright");
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 1280, height: 640 }, deviceScaleFactor: 2 })).newPage();
+await p.goto("file://" + process.cwd() + "/social-card.html");
+await p.evaluate(() => document.fonts.ready);
+await new Promise((r) => setTimeout(r, 400));
+await p.screenshot({ path: "/Users/mahammadrustamov/Desktop/remotion-library/assets/launch/social-preview.jpg", type: "jpeg", quality: 92 });
+await b.close();
+console.log("rendered");

--- a/assets/launch/tools/social-card.html
+++ b/assets/launch/tools/social-card.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body { width: 1280px; height: 640px; overflow: hidden; }
+  body {
+    font-family: -apple-system, "SF Pro Display", "Inter", system-ui, sans-serif;
+    background: #080c14;
+    color: #f8fafc;
+    position: relative;
+  }
+  /* ambient glow */
+  .glow-a { position: absolute; width: 900px; height: 900px; left: -300px; top: -450px; border-radius: 50%;
+    background: radial-gradient(circle, rgba(124,92,255,.16) 0%, transparent 62%); }
+  .glow-b { position: absolute; width: 800px; height: 800px; right: -220px; bottom: -420px; border-radius: 50%;
+    background: radial-gradient(circle, rgba(79,124,255,.14) 0%, transparent 62%); }
+  .grid-lines { position: absolute; inset: 0; opacity: .35;
+    background-image: linear-gradient(rgba(38,52,73,.35) 1px, transparent 1px),
+                      linear-gradient(90deg, rgba(38,52,73,.35) 1px, transparent 1px);
+    background-size: 64px 64px; }
+  .vignette { position: absolute; inset: 0; background: radial-gradient(120% 120% at 30% 40%, transparent 55%, rgba(8,12,20,.7) 100%); }
+
+  .left { position: absolute; left: 64px; top: 0; bottom: 0; width: 560px; display: flex; flex-direction: column; justify-content: center; gap: 28px; z-index: 3; }
+  .brand { display: flex; align-items: center; gap: 18px; }
+  .mark { width: 72px; height: 72px; border-radius: 18px; display: flex; align-items: center; justify-content: center;
+    background: linear-gradient(135deg, #7c5cff 0%, #4f7cff 100%); font-size: 46px; font-weight: 700; color: #fff;
+    box-shadow: 0 12px 40px rgba(92,108,255,.45); }
+  .word { font-size: 58px; font-weight: 700; letter-spacing: -1.5px; }
+  h1 { font-size: 33px; line-height: 1.28; font-weight: 600; letter-spacing: -0.4px; }
+  h1 .dim { color: #9caabd; font-weight: 500; }
+  .chips { display: flex; flex-wrap: wrap; gap: 10px; }
+  .chip { border: 1px solid #263449; background: rgba(17,24,39,.85); border-radius: 999px; padding: 8px 16px;
+    font-size: 16.5px; font-weight: 500; color: #cdd7e5; }
+  .chip b { color: #f8fafc; font-weight: 650; }
+  .chip.acc { border-color: rgba(79,124,255,.55); color: #9db7ff; background: rgba(79,124,255,.10); }
+  .install { display: inline-flex; align-items: center; gap: 10px; border: 1px solid #263449; background: #0b1220;
+    border-radius: 12px; padding: 14px 16px; font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 15px; color: #cdd7e5; white-space: nowrap; }
+  .install .p { color: #56637a; }
+  .install .c { color: #8fb0ff; }
+
+  .shots { position: absolute; right: -80px; top: 0; bottom: 0; width: 660px; z-index: 2; }
+  .shot { position: absolute; border-radius: 14px; overflow: hidden; border: 1px solid #2a3950;
+    box-shadow: 0 24px 70px rgba(0,0,0,.55); background: #111827; }
+  .shot img { display: block; width: 100%; }
+  .s-ai   { width: 430px; right: 210px; top: 36px; }
+  .s-kpi  { width: 470px; right: -30px; top: 350px; z-index: 5; }
+  .s-pres { width: 350px; right: 330px; bottom: -50px; z-index: 4; }
+  .fade { position: absolute; inset: 0; z-index: 3; pointer-events: none;
+    background: linear-gradient(90deg, #080c14 0%, rgba(8,12,20,.88) 42%, rgba(8,12,20,.18) 62%, transparent 78%); }
+</style>
+</head>
+<body>
+  <div class="glow-a"></div><div class="glow-b"></div>
+  <div class="grid-lines"></div>
+
+  <div class="shots">
+    <div class="shot s-ai"><img src="frames/ai-response-stream-4.png" /></div>
+    <div class="shot s-kpi"><img src="frames/kpi-number-morph-4.png" /></div>
+    <div class="shot s-pres"><img src="frames/live-presence-stack-2.png" /></div>
+  </div>
+  <div class="fade"></div>
+  <div class="vignette"></div>
+
+  <div class="left">
+    <div class="brand"><div class="mark">M</div><div class="word">Motiq</div></div>
+    <h1>Animated React &amp; shadcn components<br /><span class="dim">you install as editable source.</span></h1>
+    <div class="chips">
+      <div class="chip"><b>60+</b>&nbsp;components</div>
+      <div class="chip"><b>MIT</b>&nbsp;&amp; free</div>
+      <div class="chip acc">Reduced-motion safe</div>
+      <div class="chip acc">WCAG 2.2 AA</div>
+      <div class="chip acc">RSC-safe</div>
+    </div>
+    <div class="install"><span class="p">$</span>&nbsp;npx shadcn add <span class="c">https://motiq.dev/r/ai-response-stream</span></div>
+  </div>
+</body>
+</html>

--- a/tools/promo/README.md
+++ b/tools/promo/README.md
@@ -53,6 +53,6 @@ Category GIF tile labels must stay in sync with real component names in `apps/do
 | `motiq-vertical` | `motiq-vertical.mp4` | 9:16 1080×1920, 12s for Shorts/Reels/TikTok |
 | `motiq-card` | `motiq-card.png` | 1200×675 static for X image posts / link cards |
 
-Channel mapping + paste-ready captions: [`assets/promo/README.md`](../../assets/promo/README.md). Claim discipline: quantities must match the fact sheet in `LAUNCH.md` ("60+ components & blocks", never invented stats).
+Channel mapping + paste-ready captions: [`assets/README.md`](../../assets/README.md). Claim discipline: quantities must match the fact sheet in `LAUNCH.md` ("60+ components & blocks", never invented stats).
 
 Brand colors/copy are mirrored from `packages/tokens/styles.css` (dark theme) and `product.config.json` into [`src/theme.ts`](src/theme.ts) — update there if the brand changes. All animation is deterministic (`useCurrentFrame()`-derived; seeded PRNG for particles), enforced by `npm run test:determinism`.


### PR DESCRIPTION
## Summary
- Adds `tools/promo/` — an isolated Remotion tool that renders the Motiq promo kit (5 general GIFs, 11 category showcases, and a social kit: 16:9 trailer, 1:1 loop, 9:16 vertical, static card).
- Consolidates all marketing assets under `assets/` (`promo/` + `launch/`, moved from `launch-assets/`) with a single combined `assets/README.md` covering both kits, the channel map, and paste-ready captions.

## Boundaries & licensing
- The tool lives outside the pnpm workspace (own `npm install`), is excluded from the root ESLint run, and nothing in `packages/*` or `apps/*` imports it. The license-gated `@scope/remotion` product package is untouched.
- Local, individual marketing use falls under Remotion's free tier — license note recorded in `docs/07-remotion-strategy.md`.

## Git hygiene
- Rendered media (`assets/**/*.{gif,mp4,png,jpg}`) is gitignored — regenerable via `npm run render` / `render:social` and `assets/launch/tools`. Only source + docs are tracked (zero binaries in history).
- Deterministic-frame test passes; `pnpm lint` and `pnpm docs:check` pass.