### PR TITLE
feat(docs): rebuild homepage catalog + unify catalog navigation

### DIFF
--- a/apps/docs/app/_components/catalog-browser.tsx
+++ b/apps/docs/app/_components/catalog-browser.tsx
@@ -3,10 +3,13 @@
 import * as React from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
+import Link from "next/link";
+
 import {
   catalog,
   categories,
   categoryCount,
+  itemsByCategory,
   searchCatalog,
   kindOf,
   resolvePresentation,
@@ -17,12 +20,14 @@ import {
   type CatalogItem,
 } from "../../lib/catalog";
 import { CatalogCard } from "./catalog-card";
+import { NavSheet } from "./nav-sheet";
+import { NavChevron, NavCount, NavGroupLabel, navChildClass, navChildListClass, navRowClass } from "./sidebar-nav";
 
 type Sort = "default" | "recent";
 
-/** Sidebar groups — compact, scannable discovery (docs/56 §8). */
+/** Sidebar groups — the same grouping the component-docs rail uses, so the two
+    navigations read as one system (docs/56 §8). */
 const NAV_GROUPS: { label: string; ids: CategoryId[] }[] = [
-  { label: "Product environments", ids: ["product-backgrounds", "workflow-heroes"] },
   {
     label: "Product workflows",
     ids: [
@@ -30,17 +35,16 @@ const NAV_GROUPS: { label: string; ids: CategoryId[] }[] = [
       "developer-tools",
       "collaboration",
       "data-motion",
-      "productivity",
       "file",
       "commerce",
       "security",
       "communication",
+      "productivity",
     ],
   },
-  { label: "Creative", ids: ["text", "backgrounds", "creative"] },
+  { label: "Environments", ids: ["product-backgrounds", "workflow-heroes"] },
+  { label: "Creative", ids: ["text", "backgrounds", "creative", "mobile", "animated-shadcn", "icons"] },
   { label: "Showpieces", ids: ["cursor", "media", "scroll"] },
-  { label: "Mobile", ids: ["mobile"] },
-  { label: "Foundations", ids: ["animated-shadcn", "icons"] },
 ];
 
 // Row packing + span classes are shared from lib/catalog (also used by the homepage).
@@ -56,7 +60,6 @@ export function CatalogBrowser() {
   const sort = (params.get("sort") as Sort | null) ?? "default";
   const [query, setQuery] = React.useState(params.get("q") ?? "");
   const [drawerOpen, setDrawerOpen] = React.useState(false);
-  const [collapsed, setCollapsed] = React.useState<Record<string, boolean>>({});
 
   const setParam = React.useCallback(
     (key: string, value: string | null) => {
@@ -78,91 +81,104 @@ export function CatalogBrowser() {
   const grouped = !query && sort === "default";
 
   const chip = (active: boolean) =>
-    `rounded-full border px-3 py-1.5 text-[13px] transition-colors ${
+    `rounded-full border px-2.5 py-1 text-[12.5px] transition-colors ${
       active
-        ? "border-[var(--color-accent)] bg-[color-mix(in_oklab,var(--color-accent)_12%,transparent)] text-[var(--color-accent)]"
-        : "border-[var(--color-border)] text-[var(--color-muted)] hover:text-[var(--color-fg)]"
+        ? "border-[color-mix(in_oklab,var(--color-accent)_45%,transparent)] bg-[color-mix(in_oklab,var(--color-accent)_12%,transparent)] text-[var(--color-accent-text)]"
+        : "border-[var(--color-border)] text-[var(--color-muted)] hover:border-[color-mix(in_oklab,var(--color-fg)_22%,var(--color-border))] hover:text-[var(--color-fg)]"
     }`;
 
   const filters = (
-    <div className="flex flex-col gap-4">
-      <input
-        value={query}
-        onChange={(e) => {
-          setQuery(e.target.value);
-          setParam("q", e.target.value);
-        }}
-        placeholder="Search components…"
-        aria-label="Search components"
-        className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-[14px] text-[var(--color-fg)] outline-none placeholder:text-[var(--color-muted)] focus-visible:border-[var(--color-accent)]"
-      />
-
-      {/* Category groups with counts + active highlight + collapsible headers. */}
-      <nav className="flex flex-col gap-3" aria-label="Component categories">
-        <button
-          onClick={() => setParam("category", null)}
-          className={`flex items-center justify-between rounded-lg px-2.5 py-1.5 text-[13.5px] font-medium transition-colors ${
-            !category
-              ? "bg-[color-mix(in_oklab,var(--color-accent)_12%,transparent)] text-[var(--color-accent)]"
-              : "text-[var(--color-fg)] hover:bg-[var(--color-bg-secondary)]"
-          }`}
+    <div className="flex flex-col gap-4 text-[13.5px]">
+      {/* Search — the calm, neutral chrome of the docs rail's search trigger.
+          This one filters the grid inline rather than opening the palette. */}
+      <div className="relative">
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden
+          className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--color-muted)]"
         >
-          <span>All components</span>
-          <span className="text-[12px] tabular-nums text-[var(--color-muted)]">{catalog.length}</span>
-        </button>
+          <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="1.8" />
+          <path d="m20 20-3-3" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+        </svg>
+        <input
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setParam("q", e.target.value);
+          }}
+          placeholder="Search"
+          aria-label="Search components"
+          data-noring
+          style={{ boxShadow: "none" }}
+          className="w-full rounded-md border border-[var(--color-border)] bg-transparent py-1.5 pl-8 pr-2.5 text-[13px] text-[var(--color-fg)] outline-none transition-colors placeholder:text-[var(--color-muted)] hover:border-[color-mix(in_oklab,var(--color-fg)_22%,var(--color-border))] focus-visible:border-[color-mix(in_oklab,var(--color-fg)_38%,var(--color-border))]"
+        />
+      </div>
 
-        {NAV_GROUPS.map((group) => {
-          const isCollapsed = collapsed[group.label];
-          return (
-            <div key={group.label}>
-              <button
-                onClick={() => setCollapsed((c) => ({ ...c, [group.label]: !c[group.label] }))}
-                className="flex w-full items-center justify-between px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-muted)]"
-                aria-expanded={!isCollapsed}
-              >
-                {group.label}
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" className={isCollapsed ? "-rotate-90" : ""} aria-hidden>
-                  <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </button>
-              {!isCollapsed && (
-                <ul className="mt-0.5">
-                  {group.ids.map((id) => {
-                    const c = catById.get(id);
-                    if (!c) return null;
-                    const n = categoryCount(id);
-                    if (n === 0) return null;
-                    const active = category === id;
-                    return (
-                      <li key={id}>
-                        <button
-                          onClick={() => {
-                            setParam("category", id);
-                            setDrawerOpen(false);
-                          }}
-                          className={`flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-[13.5px] transition-colors ${
-                            active
-                              ? "bg-[color-mix(in_oklab,var(--color-accent)_12%,transparent)] font-medium text-[var(--color-accent)]"
-                              : "text-[var(--color-muted)] hover:bg-[var(--color-bg-secondary)] hover:text-[var(--color-fg)]"
-                          }`}
-                        >
-                          <span className="truncate">{c.label}</span>
-                          <span className="ml-2 text-[12px] tabular-nums opacity-70">{n}</span>
-                        </button>
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
-            </div>
-          );
-        })}
+      <nav aria-label="Component categories">
+        <ul className="space-y-0.5">
+          <li>
+            <button type="button" onClick={() => setParam("category", null)} className={navRowClass(!category)}>
+              <span>All components</span>
+              <NavCount>{catalog.length}</NavCount>
+            </button>
+          </li>
+        </ul>
+
+        {NAV_GROUPS.map((group) => (
+          <div key={group.label} className="mt-5">
+            <NavGroupLabel>{group.label}</NavGroupLabel>
+            <ul>
+              {group.ids.map((id) => {
+                const c = catById.get(id);
+                if (!c) return null;
+                const n = categoryCount(id);
+                if (!n) return null;
+                // The selected category is also the expanded one: one click
+                // filters the grid and reveals what is inside it.
+                const active = category === id;
+                return (
+                  <li key={id}>
+                    <button
+                      type="button"
+                      aria-expanded={active}
+                      onClick={() => {
+                        setParam("category", active ? null : id);
+                        setDrawerOpen(false);
+                      }}
+                      className={navRowClass(active)}
+                    >
+                      <span className="flex min-w-0 items-center gap-1.5">
+                        <NavChevron open={active} />
+                        <span className="truncate">{c.label}</span>
+                      </span>
+                      <NavCount>{n}</NavCount>
+                    </button>
+                    {active ? (
+                      <ul className={navChildListClass}>
+                        {itemsByCategory(id).map((item) => (
+                          <li key={item.slug}>
+                            <Link href={item.documentationPath} className={navChildClass(false)}>
+                              {item.name}
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))}
       </nav>
 
-      <div className="flex flex-col gap-3 border-t border-[var(--color-border)] pt-4">
+      <div className="mt-1 flex flex-col gap-3 border-t border-[var(--color-border)] pt-4">
         <div>
-          <p className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-muted)]">Highlight</p>
-          <div className="flex flex-wrap gap-2">
+          <NavGroupLabel>Highlight</NavGroupLabel>
+          <div className="flex flex-wrap gap-2 px-2.5">
             <button onClick={() => setParam("featured", null)} className={chip(!featuredOnly)}>
               All
             </button>
@@ -172,8 +188,8 @@ export function CatalogBrowser() {
           </div>
         </div>
         <div>
-          <p className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-muted)]">Type</p>
-          <div className="flex flex-wrap gap-2">
+          <NavGroupLabel>Type</NavGroupLabel>
+          <div className="flex flex-wrap gap-2 px-2.5">
             {(["all", "component", "block", "pack"] as const).map((k) => (
               <button key={k} onClick={() => setParam("kind", k)} className={chip(kind === k)}>
                 {k === "all" ? "All" : k[0].toUpperCase() + k.slice(1)}
@@ -182,8 +198,8 @@ export function CatalogBrowser() {
           </div>
         </div>
         <div>
-          <p className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-muted)]">Sort</p>
-          <div className="flex flex-wrap gap-2">
+          <NavGroupLabel>Sort</NavGroupLabel>
+          <div className="flex flex-wrap gap-2 px-2.5">
             <button onClick={() => setParam("sort", "default")} className={chip(sort === "default")}>
               Curated
             </button>
@@ -205,28 +221,34 @@ export function CatalogBrowser() {
         </p>
       </header>
 
-      {/* Mobile filter trigger (drawer below lg). */}
-      <div className="mb-4 lg:hidden">
+      {/* Mobile controls — the component-docs sub-header pattern: a sticky,
+          blurred bar whose button opens the SAME slide-in sheet, instead of the
+          old panel that expanded inline and pushed the grid down. */}
+      <div className="sticky top-14 z-30 -mx-4 mb-6 border-b border-[var(--color-border)] bg-[color-mix(in_oklab,var(--color-bg)_92%,transparent)] px-4 py-2 backdrop-blur-md sm:-mx-6 sm:px-6 lg:hidden">
         <button
-          onClick={() => setDrawerOpen((o) => !o)}
-          className="inline-flex items-center gap-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-[14px] font-medium text-[var(--color-fg)]"
+          type="button"
+          onClick={() => setDrawerOpen(true)}
           aria-expanded={drawerOpen}
+          className="inline-flex items-center gap-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-[13px] font-medium text-[var(--color-fg)]"
         >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
             <path d="M4 6h16M7 12h10M10 18h4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
           </svg>
-          Filters
-          {category ? <span className="text-[var(--color-accent)]">· {catById.get(category)?.label}</span> : null}
+          Browse
+          {category ? (
+            <span className="text-[var(--color-accent-text)]">· {catById.get(category)?.label}</span>
+          ) : null}
         </button>
-        {drawerOpen && (
-          <div className="mt-3 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg)] p-4">{filters}</div>
-        )}
       </div>
+
+      <NavSheet open={drawerOpen} onClose={() => setDrawerOpen(false)} title="Browse components">
+        {filters}
+      </NavSheet>
 
       <div className="lg:grid lg:grid-cols-[240px_1fr] lg:gap-8">
         {/* Sidebar — sticky, own bounded scroll, never determines section height. */}
         <aside className="hidden lg:block">
-          <div className="sticky top-20 max-h-[calc(100vh-6rem)] overflow-y-auto pr-2">{filters}</div>
+          <div className="sticky top-14 max-h-[calc(100dvh-3.5rem)] overflow-y-auto py-2 pr-3">{filters}</div>
         </aside>
 
         {/* Results */}

--- a/apps/docs/app/_components/category-scenes.tsx
+++ b/apps/docs/app/_components/category-scenes.tsx
@@ -1,0 +1,381 @@
+import type { ReactNode } from "react";
+
+import { CopperplateHatch } from "@/registry/backgrounds/copperplate-hatch";
+import { DecryptText } from "@/registry/text/decrypt-text";
+
+/* ------------------------------------------------------------------ *
+ * Category scenes (docs/61 §catalog). Small, deliberately SIMPLIFIED
+ * surfaces that stand for a whole catalog category on the homepage — one
+ * representative state each, drawn from what that category's components
+ * actually do. They are illustrations for a category card, not a claim
+ * about one component: the live component previews live on the category
+ * and component pages, where there is room to read them.
+ *
+ * Presentational only (no hooks) so these stay server components. All
+ * motion is CSS keyframes declared in globals.css and collapsed by the
+ * global reduced-motion rule.
+ * ------------------------------------------------------------------ */
+
+function Panel({ children, max, className }: { children: ReactNode; max?: number; className?: string }) {
+  return (
+    <div
+      className={`relative z-[1] w-full overflow-hidden rounded-[14px] border border-[var(--color-border-strong)] bg-[var(--color-surface)] shadow-[var(--shadow-lg)] ${className ?? ""}`}
+      style={max ? { maxWidth: max } : undefined}
+    >
+      {children}
+    </div>
+  );
+}
+
+function PanelHead({ title, sub, status }: { title: string; sub?: string; status?: string }) {
+  return (
+    <div className="flex items-center gap-2.5 border-b border-[var(--color-border)] px-3.5 py-[11px]">
+      <span className="text-[12.5px] font-semibold text-[var(--color-fg-secondary)]">{title}</span>
+      {sub ? <span className="truncate font-mono text-[11px] text-[var(--color-subtle)]">{sub}</span> : null}
+      {status ? (
+        <span className="ml-auto inline-flex shrink-0 items-center gap-1.5 rounded-full bg-[var(--color-accent-soft)] px-2.5 py-[3px] text-[10.5px] font-bold uppercase tracking-[0.06em] text-[var(--color-accent-text)]">
+          <i className="cat-blink h-[5px] w-[5px] rounded-full bg-[var(--color-accent)]" />
+          {status}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+/** Skeleton copy line — the neutral filler inside scene surfaces. */
+function Ln({ w, dim, tone, ml }: { w: string; dim?: boolean; tone?: string; ml?: number }) {
+  return (
+    <span
+      className="block h-[7px] rounded-[4px]"
+      style={{
+        width: w,
+        marginLeft: ml,
+        background: tone ?? (dim ? "color-mix(in oklab, var(--color-fg) 7%, transparent)" : "color-mix(in oklab, var(--color-fg) 13%, transparent)"),
+      }}
+    />
+  );
+}
+
+const CHECK = (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden>
+    <path d="M5 13l4 4L19 7" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+/* ---------- Developer console — a deployment in flight ---------- */
+function PipeNode({ label, state }: { label: string; state: "done" | "active" | "todo" }) {
+  const ring =
+    state === "done"
+      ? { borderColor: "color-mix(in oklab, var(--color-success) 60%, transparent)", color: "var(--color-success)", background: "color-mix(in oklab, var(--color-success) 10%, var(--color-surface))" }
+      : state === "active"
+        ? {
+            borderColor: "var(--color-accent)",
+            color: "var(--color-accent-text)",
+            background: "var(--color-accent-soft)",
+            boxShadow: "0 0 0 5px color-mix(in oklab, var(--color-accent) 15%, transparent), 0 0 18px color-mix(in oklab, var(--color-accent) 30%, transparent)",
+          }
+        : { borderColor: "var(--color-border-strong)", color: "var(--color-subtle)", background: "var(--color-surface)" };
+  return (
+    <span className="flex w-[64px] shrink-0 flex-col items-center gap-2">
+      <span className="grid h-8 w-8 place-items-center rounded-full border-[1.5px]" style={ring}>
+        {state === "done" ? (
+          CHECK
+        ) : state === "active" ? (
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden>
+            <path d="M12 3v18M5 8l7-5 7 5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        ) : (
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden>
+            <circle cx="12" cy="12" r="8" stroke="currentColor" strokeWidth="2" />
+          </svg>
+        )}
+      </span>
+      <span className="text-[11px] font-semibold text-[var(--color-muted)]">{label}</span>
+    </span>
+  );
+}
+function PipeLine({ fill, run }: { fill?: boolean; run?: boolean }) {
+  return (
+    <span
+      className="relative mb-[21px] h-[2px] flex-1 overflow-hidden rounded-[2px]"
+      style={{ background: fill ? "color-mix(in oklab, var(--color-success) 55%, var(--color-border-strong))" : "var(--color-border-strong)" }}
+    >
+      {run ? (
+        <i
+          className="cat-sweep absolute inset-y-0 left-0 w-[45%]"
+          style={{ background: "linear-gradient(to right, transparent, var(--color-accent), transparent)" }}
+        />
+      ) : null}
+    </span>
+  );
+}
+
+export function DeveloperScene() {
+  return (
+    <Panel max={560}>
+      <PanelHead title="production" sub="deploy #482 · main@e4f21c" status="Deploying" />
+      <div className="flex items-center px-[18px] pb-2 pt-5">
+        <PipeNode label="Build" state="done" />
+        <PipeLine fill />
+        <PipeNode label="Test" state="done" />
+        <PipeLine run />
+        <PipeNode label="Deploy" state="active" />
+        <PipeLine />
+        <PipeNode label="Verify" state="todo" />
+      </div>
+      <div className="mx-[18px] mb-3.5 flex items-center gap-2 overflow-hidden whitespace-nowrap rounded-[9px] bg-[var(--color-bg-elevated)] px-[11px] py-2 font-mono text-[10.5px] text-[var(--color-muted)]">
+        <span className="text-[var(--color-success)]">✓</span> pushed image registry/web:e4f21c · rolling out 3 of 8 replicas…
+      </div>
+    </Panel>
+  );
+}
+
+/* ---------- Collaboration — a shared document, live ---------- */
+function Avatar({ initials, color, live, first }: { initials: string; color: string; live?: boolean; first?: boolean }) {
+  return (
+    <span
+      className={`relative grid h-[30px] w-[30px] place-items-center rounded-full border-2 border-[var(--color-surface)] text-[10.5px] font-bold ${first ? "" : "-ml-2"}`}
+      style={{ background: color, color: color.startsWith("var(") ? "var(--color-muted)" : "#fff" }}
+    >
+      {initials}
+      {live ? <i className="cat-ring absolute -inset-[5px] rounded-full border-[1.5px] border-[var(--color-secondary-accent)]" /> : null}
+    </span>
+  );
+}
+
+export function CollaborationScene() {
+  return (
+    <Panel max={280}>
+      <div className="flex items-center gap-3 px-4 py-3.5">
+        <span className="grid h-[30px] w-[30px] shrink-0 place-items-center rounded-[9px] bg-[var(--color-secondary-accent-soft)] text-[var(--color-secondary-accent)]">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden>
+            <path d="M6 3h9l4 4v14H6z M14 3v5h5" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" />
+          </svg>
+        </span>
+        <span className="min-w-0">
+          <b className="block truncate text-[12.5px] font-semibold text-[var(--color-fg-secondary)]">Q3 launch plan</b>
+          <span className="text-[10.5px] text-[var(--color-subtle)]">7 online now</span>
+        </span>
+        <span className="ml-auto flex shrink-0">
+          <Avatar initials="AK" color="#3e5ae8" first />
+          <Avatar initials="MJ" color="#0e9488" live />
+          <Avatar initials="RS" color="#b45309" />
+          <Avatar initials="+4" color="var(--color-surface-strong)" />
+        </span>
+      </div>
+      <div className="flex flex-col gap-[9px] px-4 pb-4 pt-1">
+        <Ln w="88%" />
+        <Ln w="72%" dim />
+        <span className="flex items-center gap-2">
+          <span className="rounded-[4px_4px_4px_0] bg-[#0e9488] px-1.5 py-[1.5px] text-[9.5px] font-bold text-white">Mira</span>
+          <Ln w="44%" tone="color-mix(in oklab, #0e9488 35%, transparent)" />
+        </span>
+        <Ln w="60%" dim />
+      </div>
+    </Panel>
+  );
+}
+
+/* ---------- File workflows — a queue mid-upload ---------- */
+function UploadRow({ kind, name, pct, state }: { kind: string; name: string; pct?: number; state: "done" | "active" | "queued" }) {
+  return (
+    <div className={`flex items-center gap-2.5 rounded-[11px] border border-[var(--color-border)] bg-[var(--color-bg-elevated)] px-3 py-[9px] ${state === "queued" ? "opacity-60" : ""}`}>
+      <span className="grid h-[30px] w-[30px] shrink-0 place-items-center rounded-lg bg-[var(--color-accent-soft)] text-[9.5px] font-bold text-[var(--color-accent-text)]">{kind}</span>
+      <span className="min-w-0 flex-1">
+        <b className="block truncate text-[11.5px] font-semibold text-[var(--color-fg-secondary)]">{name}</b>
+        {state === "active" ? (
+          <span className="mt-[5px] block h-1 overflow-hidden rounded bg-[var(--color-surface-strong)]">
+            <i className="cat-grow block h-full rounded bg-[var(--color-accent)]" />
+          </span>
+        ) : null}
+      </span>
+      <span className={`shrink-0 text-[10.5px] tabular-nums ${state === "done" ? "text-[var(--color-success)]" : "text-[var(--color-muted)]"}`}>
+        {state === "done" ? "✓ Done" : state === "queued" ? "Queued" : `${pct}%`}
+      </span>
+    </div>
+  );
+}
+
+export function FileScene() {
+  return (
+    <Panel max={280}>
+      <PanelHead title="Uploading 3 files" status="2 of 3" />
+      <div className="flex flex-col gap-2 px-3.5 pb-3.5 pt-3">
+        <UploadRow kind="PDF" name="brand-guidelines.pdf" state="done" />
+        <UploadRow kind="PNG" name="hero-cover@2x.png" state="active" pct={64} />
+        <UploadRow kind="ZIP" name="assets-export.zip" state="queued" />
+      </div>
+    </Panel>
+  );
+}
+
+/* ---------- Security & accounts — a passkey confirmation ---------- */
+export function SecurityScene() {
+  return (
+    <Panel max={250}>
+      <div className="px-5 pb-[18px] pt-[22px] text-center">
+        <span
+          className="mx-auto mb-3 grid h-[58px] w-[58px] place-items-center rounded-[17px] bg-[var(--color-accent-soft)] text-[var(--color-accent-text)]"
+          style={{ border: "1px solid color-mix(in oklab, var(--color-accent) 34%, transparent)", boxShadow: "0 0 26px color-mix(in oklab, var(--color-accent) 22%, transparent)" }}
+        >
+          <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden>
+            <path d="M12 3l7 3v5c0 5-3.5 8-7 9-3.5-1-7-4-7-9V6zM9 12l2 2 4-4" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </span>
+        <b className="block text-[13px] font-semibold text-[var(--color-fg-secondary)]">Confirm with Touch ID</b>
+        <span className="mt-[3px] block text-[11px] text-[var(--color-subtle)]">Your passkey stays on this device</span>
+        <span className="mx-auto mt-[13px] block w-fit rounded-[9px] bg-[var(--color-accent)] px-[18px] py-[7px] text-[11.5px] font-semibold text-[var(--color-accent-fg)]">
+          Continue
+        </span>
+        <span className="mt-[13px] flex justify-center gap-[5px]">
+          {[true, true, false, false].map((on, i) => (
+            <i key={i} className="h-[3.5px] w-[26px] rounded" style={{ background: on ? "var(--color-accent)" : "var(--color-surface-strong)" }} />
+          ))}
+        </span>
+      </div>
+    </Panel>
+  );
+}
+
+/* ---------- Productivity — a board mid-drag ---------- */
+function KCard({ lines, lift }: { lines: string[]; lift?: boolean }) {
+  return (
+    <div
+      className={`mb-1.5 rounded-lg border bg-[var(--color-surface)] px-2 py-[7px] ${lift ? "cat-lift shadow-[var(--shadow-md)]" : ""}`}
+      style={{ borderColor: lift ? "var(--fam)" : "var(--color-border)" }}
+    >
+      {lines.map((w, i) => (
+        <span key={i} className={i ? "mt-[5px] block" : "block"}>
+          <Ln w={w} dim={i > 0} />
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function ProductivityScene() {
+  return (
+    <Panel max={300}>
+      <div className="flex gap-[9px] p-3.5">
+        {[
+          { h: "To do", dot: "var(--fam)", cards: [["80%", "55%"], ["65%"]], slot: false },
+          { h: "Doing", dot: "#3e5ae8", cards: [["85%", "48%"]], slot: true },
+          { h: "Done", dot: "var(--color-success)", cards: [["70%"]], slot: false },
+        ].map((col) => (
+          <div key={col.h} className="min-w-0 flex-1 rounded-[11px] border border-[var(--color-border)] bg-[var(--color-bg-elevated)] p-2">
+            <h5 className="mx-0.5 mb-2 mt-px flex items-center gap-[5px] text-[9.5px] font-bold uppercase tracking-[0.08em] text-[var(--color-subtle)]">
+              <i className="h-[5px] w-[5px] rounded-full" style={{ background: col.dot }} />
+              {col.h}
+            </h5>
+            {col.slot ? (
+              <div
+                className="mb-1.5 h-[30px] rounded-lg"
+                style={{ border: "1.5px dashed color-mix(in oklab, var(--fam) 45%, transparent)", background: "color-mix(in oklab, var(--fam) 6%, transparent)" }}
+              />
+            ) : null}
+            {col.cards.map((lines, i) => (
+              <KCard key={i} lines={lines} lift={col.slot && i === 0} />
+            ))}
+          </div>
+        ))}
+      </div>
+    </Panel>
+  );
+}
+
+/* ---------- Text animations — the real Decrypt Text, headline + terminal ----------
+   The one scene that IS a live registry component: it needs no controls or
+   fixture data to read, so the category is shown by the thing itself. */
+export function TextScene() {
+  return (
+    <div className="relative z-[1] flex w-full flex-col items-center gap-4 text-center">
+      <DecryptText
+        text="Ship interfaces that feel alive."
+        // decorative inside a card — the card's own <h3> is the heading here
+        as="div"
+        trigger="inview"
+        loop={7000}
+        seed={7}
+        className="text-[clamp(24px,3.2vw,40px)] font-bold tracking-[-0.022em] text-[var(--color-fg)]"
+      />
+      <DecryptText
+        text="motiq add decrypt-text — resolved in 84ms"
+        variant="terminal"
+        trigger="inview"
+        startDelay={900}
+        loop={7000}
+        seed={13}
+        className="w-auto"
+      />
+    </div>
+  );
+}
+
+/* ---------- Workflow heroes — copy + CTAs beside a live agent run ---------- */
+export function HeroBlockScene() {
+  return (
+    <div
+      className="absolute inset-0 grid grid-cols-[1fr_1.05fr] items-center gap-3 py-[22px] pl-[22px] pr-[18px]"
+      style={{ background: "radial-gradient(80% 100% at 85% 0%, color-mix(in oklab, var(--color-accent) 10%, transparent), transparent 65%)" }}
+    >
+      <div>
+        <span className="mb-[7px] block h-[11px] w-[92%] rounded-[6px]" style={{ background: "color-mix(in oklab, var(--color-fg) 24%, transparent)" }} />
+        <span className="mb-[7px] block h-[11px] w-[66%] rounded-[6px]" style={{ background: "color-mix(in oklab, var(--color-fg) 24%, transparent)" }} />
+        <span className="mt-[9px] block h-[7px] w-[84%] rounded-[6px]" style={{ background: "color-mix(in oklab, var(--color-fg) 10%, transparent)" }} />
+        <span className="mt-[11px] flex gap-[7px]">
+          <i className="h-[21px] w-[68px] rounded-[7px] bg-[var(--color-accent)] opacity-95" />
+          <i className="h-[21px] w-[68px] rounded-[7px] border border-[var(--color-border-strong)]" />
+        </span>
+      </div>
+      <div className="rounded-xl border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-[11px] py-2.5 shadow-[var(--shadow-md)]">
+        {[
+          { s: "done", label: "Plan research", tool: null },
+          { s: "act", label: "Tool call", tool: "search_docs()" },
+          { s: "todo", label: "Await approval", tool: null },
+        ].map((step) => (
+          <div key={step.label} className="flex items-center gap-2 py-[5px]">
+            <span
+              className={`grid h-[18px] w-[18px] shrink-0 place-items-center rounded-full border-[1.5px] text-[10px] ${step.s === "act" ? "cat-blink" : ""}`}
+              style={
+                step.s === "done"
+                  ? { borderColor: "color-mix(in oklab, var(--color-success) 60%, transparent)", color: "var(--color-success)", background: "var(--color-surface)" }
+                  : step.s === "act"
+                    ? { borderColor: "var(--color-accent)", color: "var(--color-accent-text)", background: "var(--color-accent-soft)", boxShadow: "0 0 0 3.5px color-mix(in oklab, var(--color-accent) 15%, transparent)" }
+                    : { borderColor: "var(--color-border-strong)", color: "var(--color-subtle)", background: "var(--color-surface)" }
+              }
+            >
+              {step.s === "done" ? "✓" : step.s === "act" ? "●" : "○"}
+            </span>
+            <b className={`whitespace-nowrap text-[10.5px] font-semibold ${step.s === "act" ? "text-[var(--color-fg)]" : "text-[var(--color-fg-secondary)]"}`}>{step.label}</b>
+            {step.tool ? (
+              <span className="ml-auto whitespace-nowrap rounded-[5px] bg-[var(--color-accent-soft)] px-1.5 py-[2px] font-mono text-[9px] text-[var(--color-accent-text)]">
+                {step.tool}
+              </span>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ---------- Ambient backgrounds — the real Copperplate Hatch ----------
+   The engraver's cross-hatch plate, rendered live rather than evoked. It
+   commits to a fixed dark palette by design (see its brief), so this one card
+   stays dark in the light theme — that is the component, not a theming bug. */
+export function AmbientScene() {
+  return (
+    <span className="absolute inset-0 block">
+      <CopperplateHatch
+        className="h-full w-full"
+        // thinned for card scale — at full density the plate reads as noise in
+        // a ~350px cell instead of legible engraving
+        density={0.55}
+        intensity={1.1}
+        focalPoint={[{ x: 0.68, y: 0.3 }]}
+        seed={11}
+        pauseWhenHidden
+      />
+    </span>
+  );
+}

--- a/apps/docs/app/_components/docs-sidebar.tsx
+++ b/apps/docs/app/_components/docs-sidebar.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import * as React from "react";
-import { createPortal } from "react-dom";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import { categories, categoryCount, itemsByCategory, bySlug, type CategoryId } from "../../lib/catalog";
 import { packs } from "../../lib/packs";
+import { NavSheet } from "./nav-sheet";
 import { SearchTrigger } from "./search";
+import { NavChevron, NavCount, NavGroupLabel, navChildClass, navChildListClass, navRowClass } from "./sidebar-nav";
 
 /**
  * Documentation navigation for component pages (docs shell, left rail).
@@ -56,14 +57,6 @@ const START_LINKS: [string, string][] = [
 
 const catLabel = (id: CategoryId) => categories.find((c) => c.id === id)?.label ?? id;
 
-function Chevron({ open }: { open: boolean }) {
-  return (
-    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" className={open ? "" : "-rotate-90"} aria-hidden>
-      <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
-}
-
 /** The nav tree itself — shared by the desktop rail and the mobile sheet. */
 function DocsNavTree({ activeSlug }: { activeSlug?: string }) {
   const pathname = usePathname();
@@ -86,11 +79,7 @@ function DocsNavTree({ activeSlug }: { activeSlug?: string }) {
             <Link
               href={href}
               aria-current={pathname === href ? "page" : undefined}
-              className={`block rounded-md px-2.5 py-1.5 font-medium ${
-                pathname === href
-                  ? "bg-[color-mix(in_oklab,var(--color-accent)_12%,transparent)] text-[var(--color-accent-text)]"
-                  : "text-[var(--color-fg)] hover:bg-[var(--color-bg-secondary)]"
-              }`}
+              className={navRowClass(pathname === href)}
             >
               {label}
             </Link>
@@ -100,9 +89,7 @@ function DocsNavTree({ activeSlug }: { activeSlug?: string }) {
 
       {NAV_GROUPS.map((group) => (
         <div key={group.label} className="mt-5">
-          <p className="mb-1.5 px-2.5 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-muted)]">
-            {group.label}
-          </p>
+          <NavGroupLabel>{group.label}</NavGroupLabel>
           <ul>
             {group.ids.map((id) => {
               const n = categoryCount(id);
@@ -115,16 +102,16 @@ function DocsNavTree({ activeSlug }: { activeSlug?: string }) {
                     type="button"
                     aria-expanded={isOpen}
                     onClick={() => setOpen((s) => ({ ...s, [id]: !s[id] }))}
-                    className="flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-1.5 text-left font-medium text-[var(--color-fg)] hover:bg-[var(--color-bg-secondary)]"
+                    className={navRowClass(false)}
                   >
                     <span className="flex items-center gap-1.5">
-                      <Chevron open={isOpen} />
+                      <NavChevron open={isOpen} />
                       {catLabel(id)}
                     </span>
-                    <span className="text-[11.5px] tabular-nums text-[var(--color-muted)]">{n}</span>
+                    <NavCount>{n}</NavCount>
                   </button>
                   {isOpen ? (
-                    <ul className="mb-1 ml-4 border-l border-[var(--color-border)] pl-2">
+                    <ul className={navChildListClass}>
                       {items.map((item) => {
                         const active = item.slug === activeSlug;
                         return (
@@ -133,11 +120,7 @@ function DocsNavTree({ activeSlug }: { activeSlug?: string }) {
                               href={item.documentationPath}
                               ref={active ? activeRef : undefined}
                               aria-current={active ? "page" : undefined}
-                              className={`block truncate rounded-md px-2 py-[5px] text-[13px] ${
-                                active
-                                  ? "bg-[color-mix(in_oklab,var(--color-accent)_12%,transparent)] font-medium text-[var(--color-accent-text)]"
-                                  : "text-[var(--color-muted)] hover:bg-[var(--color-bg-secondary)] hover:text-[var(--color-fg)]"
-                              }`}
+                              className={navChildClass(active)}
                             >
                               {item.name}
                             </Link>
@@ -154,9 +137,7 @@ function DocsNavTree({ activeSlug }: { activeSlug?: string }) {
       ))}
 
       <div className="mt-5">
-        <p className="mb-1.5 px-2.5 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-muted)]">
-          Workflow packs
-        </p>
+        <NavGroupLabel>Workflow packs</NavGroupLabel>
         <ul className="space-y-0.5">
           {packs.map((p) => {
             const href = `/packs/${p.slug}`;
@@ -166,11 +147,7 @@ function DocsNavTree({ activeSlug }: { activeSlug?: string }) {
                 <Link
                   href={href}
                   aria-current={active ? "page" : undefined}
-                  className={`block truncate rounded-md px-2.5 py-1.5 text-[13px] ${
-                    active
-                      ? "bg-[color-mix(in_oklab,var(--color-accent)_12%,transparent)] font-medium text-[var(--color-accent-text)]"
-                      : "text-[var(--color-muted)] hover:bg-[var(--color-bg-secondary)] hover:text-[var(--color-fg)]"
-                  }`}
+                  className={navChildClass(active)}
                 >
                   {p.name}
                 </Link>
@@ -197,41 +174,6 @@ export function DocsSidebar({ activeSlug }: { activeSlug?: string }) {
   );
 }
 
-function useFocusTrap(active: boolean, containerRef: React.RefObject<HTMLElement | null>, onClose: () => void) {
-  React.useEffect(() => {
-    if (!active) return;
-    const el = containerRef.current;
-    if (!el) return;
-    const prevActive = document.activeElement as HTMLElement | null;
-    const sel = 'a[href],button:not([disabled]),input,select,textarea,[tabindex]:not([tabindex="-1"])';
-    const focusables = () => Array.from(el.querySelectorAll<HTMLElement>(sel)).filter((n) => n.offsetParent !== null);
-    focusables()[0]?.focus();
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose();
-        return;
-      }
-      if (e.key !== "Tab") return;
-      const items = focusables();
-      if (items.length === 0) return;
-      const idx = items.indexOf(document.activeElement as HTMLElement);
-      if (e.shiftKey && idx <= 0) {
-        e.preventDefault();
-        items[items.length - 1].focus();
-      } else if (!e.shiftKey && idx === items.length - 1) {
-        e.preventDefault();
-        items[0].focus();
-      }
-    };
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("keydown", onKey);
-      prevActive?.focus?.();
-    };
-  }, [active, containerRef, onClose]);
-}
-
 /**
  * Sub-header controls for viewports without the fixed rails: a docs-menu
  * button (below lg) and an "On this page" disclosure (below xl, i.e. wherever
@@ -241,30 +183,14 @@ export function DocsMobileControls({ activeSlug, toc }: { activeSlug?: string; t
   const pathname = usePathname();
   const [menuOpen, setMenuOpen] = React.useState(false);
   const [tocOpen, setTocOpen] = React.useState(false);
-  const [mounted, setMounted] = React.useState(false);
-  const sheetRef = React.useRef<HTMLDivElement>(null);
   const tocRef = React.useRef<HTMLDivElement>(null);
   const tocBtnRef = React.useRef<HTMLButtonElement>(null);
-
-  React.useEffect(() => setMounted(true), []);
 
   // Close both on route change.
   React.useEffect(() => {
     setMenuOpen(false);
     setTocOpen(false);
   }, [pathname]);
-
-  // Body scroll lock while the sheet is open.
-  React.useEffect(() => {
-    if (!menuOpen) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = prev;
-    };
-  }, [menuOpen]);
-
-  useFocusTrap(menuOpen, sheetRef, () => setMenuOpen(false));
 
   // "On this page": click-outside + Esc close.
   React.useEffect(() => {
@@ -341,42 +267,13 @@ export function DocsMobileControls({ activeSlug, toc }: { activeSlug?: string; t
         ) : null}
       </div>
 
-      {/* Documentation sheet — portaled so backdrop-blur ancestors can't trap it. */}
-      {mounted && menuOpen
-        ? createPortal(
-            <div className="fixed inset-0 z-[60] lg:hidden" role="dialog" aria-modal="true" aria-label="Documentation menu">
-              <div
-                className="absolute inset-0 bg-[color-mix(in_oklab,var(--color-bg)_55%,black)]/70"
-                onClick={() => setMenuOpen(false)}
-              />
-              <div
-                ref={sheetRef}
-                className="absolute inset-y-0 left-0 flex w-[min(88vw,340px)] flex-col border-r border-[var(--color-border)] bg-[var(--color-bg)] pb-[env(safe-area-inset-bottom)]"
-              >
-                <div className="flex h-14 shrink-0 items-center justify-between border-b border-[var(--color-border)] px-4">
-                  <span className="text-[15px] font-semibold text-[var(--color-fg)]">Documentation</span>
-                  <button
-                    type="button"
-                    aria-label="Close documentation menu"
-                    onClick={() => setMenuOpen(false)}
-                    className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--color-border)] text-[var(--color-fg)]"
-                  >
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
-                      <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                    </svg>
-                  </button>
-                </div>
-                <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-4">
-                  {/* No search trigger here: the global header's search icon stays
-                      visible on mobile, and a palette opened from inside this
-                      sheet would fight its focus trap. */}
-                  <DocsNavTree activeSlug={activeSlug} />
-                </div>
-              </div>
-            </div>,
-            document.body,
-          )
-        : null}
+      {/* Same sheet the /components rail uses — see nav-sheet.tsx. */}
+      <NavSheet open={menuOpen} onClose={() => setMenuOpen(false)} title="Documentation">
+        {/* No search trigger here: the global header's search icon stays visible
+            on mobile, and a palette opened from inside this sheet would fight
+            its focus trap. */}
+        <DocsNavTree activeSlug={activeSlug} />
+      </NavSheet>
     </div>
   );
 }

--- a/apps/docs/app/_components/install-chip.tsx
+++ b/apps/docs/app/_components/install-chip.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import * as React from "react";
+
+/**
+ * Compact one-click install command (homepage pack cards). Displays the short
+ * extensionless form; copies the full canonical command from `installCommand()`.
+ */
+export function InstallChip({ command, display }: { command: string; display: string }) {
+  const [copied, setCopied] = React.useState(false);
+  const timer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  React.useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+
+  return (
+    <button
+      type="button"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(command);
+          setCopied(true);
+          if (timer.current) clearTimeout(timer.current);
+          timer.current = setTimeout(() => setCopied(false), 1600);
+        } catch {
+          /* clipboard unavailable — the visible command is still selectable */
+        }
+      }}
+      aria-label={`Copy install command: ${command}`}
+      className="group/install flex h-10 min-w-0 flex-1 items-center gap-2.5 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-elevated)] px-3.5 text-left font-mono text-[12px] text-[var(--color-muted)] transition-colors hover:border-[var(--color-border-strong)] hover:text-[var(--color-fg-secondary)]"
+    >
+      <span className="truncate">
+        npx shadcn add <span className="font-medium text-[var(--color-accent-text)]">{display}</span>
+      </span>
+      <span className="ml-auto shrink-0" aria-hidden>
+        {copied ? (
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="text-[var(--color-success)]">
+            <path d="M5 13l4 4L19 7" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        ) : (
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="text-[var(--color-subtle)]">
+            <rect x="9" y="9" width="11" height="11" rx="2" stroke="currentColor" strokeWidth="1.7" />
+            <path d="M5 15V5a1 1 0 011-1h10" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
+          </svg>
+        )}
+      </span>
+      <span className="sr-only" role="status">{copied ? "Copied" : ""}</span>
+    </button>
+  );
+}

--- a/apps/docs/app/_components/media-gallery-hero.tsx
+++ b/apps/docs/app/_components/media-gallery-hero.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+
+import { VelocityMarquee, type VelocityMarqueeRow } from "@/registry/media/velocity-marquee";
+import { useSceneImages, type SceneSpec } from "../_previews/media-scenes";
+
+/* -------------------------------------------------------------------------
+ * Lead card of the homepage catalog grid (docs/61 §catalog): the real Velocity
+ * Marquee, two counter-rotating rails that drift at rest and surge with scroll
+ * velocity — the most kinetic thing in the catalog, so it earns the widest slot.
+ *
+ * Artwork is generated in-canvas by the shared media-scenes helper (the same one
+ * the component's own preview uses), so this ships no image assets and re-paints
+ * itself when the theme flips. Shell mirrors CategoryCard — count chip, meta row
+ * with a go-arrow — but stays a <div>: the marquee is pointer/keyboard reactive,
+ * so it must not sit inside a card-wide link.
+ * ---------------------------------------------------------------------- */
+
+const SPECS: SceneSpec[] = [
+  { kind: "land", t: 0.3, seed: 11 },
+  { kind: "geo", v: 0 },
+  { kind: "land", t: 0.62, seed: 23 },
+  { kind: "orbs" },
+  { kind: "city" },
+  { kind: "land", t: 0.08, seed: 31 },
+  { kind: "geo", v: 2 },
+  { kind: "land", t: 0.9, seed: 41 },
+];
+
+const MEDIA: [string, string][] = [
+  ["Basin at noon", "RAW"],
+  ["Signal bloom", "GEN"],
+  ["Ridgeline, dusk", "RAW"],
+  ["Night transit", "GEN"],
+  ["Glass district", "RAW"],
+  ["First light", "RAW"],
+  ["Static tide", "GEN"],
+  ["Amber field", "RAW"],
+];
+
+const RAIL_TWO = [
+  "Orbital Gallery",
+  "Flow Warp Image",
+  "Velocity Marquee",
+  "Filmstrip Scrub",
+  "Compare Reveal",
+];
+
+export function MediaGalleryHero({ count, href }: { count: number; href: string }) {
+  const images = useSceneImages(SPECS, 336, 208);
+
+  const rows = React.useMemo<VelocityMarqueeRow[]>(
+    () => [
+      {
+        id: "captures",
+        label: "Recent captures",
+        direction: 1,
+        items: MEDIA.map(([name, tag], i) => ({
+          id: `capture-${i}`,
+          node: (
+            <div className="w-[168px] overflow-hidden rounded-[10px] border border-[var(--color-border)] bg-[var(--color-surface)]">
+              {images[i] ? (
+                <img src={images[i]} alt="" className="block h-[104px] w-full object-cover" />
+              ) : (
+                <div className="h-[104px] w-full bg-[var(--color-surface-2)]" />
+              )}
+              <div className="flex items-center justify-between gap-2 px-3 py-2 text-[11.5px] font-semibold leading-none text-[var(--color-fg-secondary)]">
+                {name}
+                <span className="font-mono text-[10px] leading-none text-[var(--color-muted)]">{tag}</span>
+              </div>
+            </div>
+          ),
+        })),
+      },
+      {
+        id: "components",
+        label: "Components in this category",
+        direction: -1,
+        items: RAIL_TWO.map((name, i) => ({
+          id: `cat-${i}`,
+          node: (
+            <span className="flex h-[52px] items-center gap-2.5 whitespace-nowrap rounded-[10px] border border-[var(--color-border)] bg-[var(--color-surface)] px-5 text-[13.5px] font-semibold tracking-[-0.01em] text-[var(--color-muted)]">
+              <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-[var(--fam)]" />
+              {name}
+            </span>
+          ),
+        })),
+      },
+    ],
+    [images],
+  );
+
+  return (
+    <div
+      className="group relative flex h-full flex-col overflow-hidden rounded-[22px] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-sm)] transition-all duration-300 hover:border-[color-mix(in_oklab,var(--fam)_45%,var(--color-border))] hover:shadow-[var(--shadow-md)]"
+      style={{ ["--fam" as string]: "#22c7d9" }}
+    >
+      <div
+        className="relative flex min-h-[300px] flex-1 items-center overflow-hidden border-b border-[var(--color-border)] py-8"
+        style={{
+          background:
+            "radial-gradient(100% 100% at 50% 0%, color-mix(in oklab, var(--fam) 9%, transparent), transparent 72%), var(--color-bg-elevated)",
+        }}
+      >
+        <VelocityMarquee rows={rows} baseSpeed={26} maxSkew={5} showMeter={false} className="w-full" aria-label="Media gallery marquee" />
+
+        <span
+          className="pointer-events-none absolute left-[15px] top-[15px] z-[3] inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold tabular-nums tracking-[0.04em]"
+          style={{
+            color: "var(--fam)",
+            background: "color-mix(in oklab, var(--fam) 13%, var(--color-surface))",
+            borderColor: "color-mix(in oklab, var(--fam) 32%, transparent)",
+          }}
+        >
+          {count} components
+        </span>
+      </div>
+
+      <div className="flex items-center gap-3.5 px-[19px] py-[17px]">
+        <span className="min-w-0">
+          <h3 className="text-[16.5px] font-semibold tracking-[-0.012em] text-[var(--color-fg)]">
+            <Link href={href} className="outline-none hover:text-[var(--color-accent-text)]">
+              Media &amp; galleries
+            </Link>
+          </h3>
+          <p className="mt-0.5 truncate text-[13.5px] text-[var(--color-muted)]">
+            Galleries, scrubbers, and image effects with real physics.
+          </p>
+        </span>
+        <Link
+          href={href}
+          aria-label="Browse media and galleries"
+          className="ml-auto grid h-[38px] w-[38px] shrink-0 place-items-center rounded-full border border-[var(--color-border-strong)] text-[var(--color-muted)] transition-all duration-300 [transition-timing-function:cubic-bezier(0.2,0,0,1)] group-hover:-rotate-45 group-hover:border-[var(--color-accent)] group-hover:bg-[var(--color-accent)] group-hover:text-[var(--color-accent-fg)]"
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden>
+            <path d="M5 12h13M13 6l6 6-6 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/app/_components/nav-sheet.tsx
+++ b/apps/docs/app/_components/nav-sheet.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import * as React from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * The shared mobile navigation sheet — a left slide-in used by both the
+ * component-docs rail and the /components catalog rail, so the two behave
+ * identically on phones: portaled out of any backdrop-filter ancestor, modal,
+ * focus-trapped, Esc-closable, with the page behind it scroll-locked.
+ */
+
+export function useFocusTrap(active: boolean, containerRef: React.RefObject<HTMLElement | null>, onClose: () => void) {
+  React.useEffect(() => {
+    if (!active) return;
+    const el = containerRef.current;
+    if (!el) return;
+    const prevActive = document.activeElement as HTMLElement | null;
+    const sel = 'a[href],button:not([disabled]),input,select,textarea,[tabindex]:not([tabindex="-1"])';
+    const focusables = () => Array.from(el.querySelectorAll<HTMLElement>(sel)).filter((n) => n.offsetParent !== null);
+    focusables()[0]?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const items = focusables();
+      if (items.length === 0) return;
+      const idx = items.indexOf(document.activeElement as HTMLElement);
+      if (e.shiftKey && idx <= 0) {
+        e.preventDefault();
+        items[items.length - 1].focus();
+      } else if (!e.shiftKey && idx === items.length - 1) {
+        e.preventDefault();
+        items[0].focus();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      prevActive?.focus?.();
+    };
+  }, [active, containerRef, onClose]);
+}
+
+export function NavSheet({
+  open,
+  onClose,
+  title,
+  children,
+}: {
+  open: boolean;
+  onClose: () => void;
+  /** Sheet heading, also its accessible name. */
+  title: string;
+  children: React.ReactNode;
+}) {
+  const sheetRef = React.useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => setMounted(true), []);
+
+  // Body scroll lock while the sheet is open.
+  React.useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  useFocusTrap(open, sheetRef, onClose);
+
+  if (!mounted || !open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[60] lg:hidden" role="dialog" aria-modal="true" aria-label={title}>
+      <div className="absolute inset-0 bg-[color-mix(in_oklab,var(--color-bg)_55%,black)]/70" onClick={onClose} />
+      <div
+        ref={sheetRef}
+        className="absolute inset-y-0 left-0 flex w-[min(88vw,340px)] flex-col border-r border-[var(--color-border)] bg-[var(--color-bg)] pb-[env(safe-area-inset-bottom)]"
+      >
+        <div className="flex h-14 shrink-0 items-center justify-between border-b border-[var(--color-border)] px-4">
+          <span className="text-[15px] font-semibold text-[var(--color-fg)]">{title}</span>
+          <button
+            type="button"
+            aria-label={`Close ${title.toLowerCase()}`}
+            onClick={onClose}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--color-border)] text-[var(--color-fg)]"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+              <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-4">{children}</div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/docs/app/_components/reveal.tsx
+++ b/apps/docs/app/_components/reveal.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import * as React from "react";
+
+/**
+ * Staggered scroll reveal for the homepage catalog grid (docs/61 §catalog).
+ * Cards rise and fade in once as they enter the viewport — the entrance is the
+ * section's one orchestrated moment; every other loop inside the cards is
+ * ambient. Mirrors LazyPreview's observer conventions:
+ *   - reveals immediately if the element is already on/near screen at mount,
+ *     so above-the-fold cards never flash empty (or capture blank in shots);
+ *   - one-shot: the observer disconnects after the first reveal;
+ *   - reduced motion + no-JS both fall back to plain, fully visible content
+ *     (see the `.reveal` rules in globals.css).
+ */
+export function Reveal({
+  children,
+  delay = 0,
+  className,
+}: {
+  children: React.ReactNode;
+  /** Stagger, in ms, applied as a transition-delay. */
+  delay?: number;
+  className?: string;
+}) {
+  const ref = React.useRef<HTMLDivElement>(null);
+  /**
+   * "idle" is the SSR state and renders NO attribute — the markup ships fully
+   * visible, so a no-JS agent or a failed hydration can never blank the grid.
+   * The hidden "out" state is only ever applied on the client, and only to
+   * elements that are still below the fold, where the flip cannot be seen.
+   */
+  const [state, setState] = React.useState<"idle" | "out" | "in">("idle");
+  const shown = state === "in";
+
+  React.useEffect(() => {
+    if (shown) return;
+    const el = ref.current;
+    if (!el) return;
+
+    // Geometry is the source of truth; the observer is only a cheap trigger.
+    const check = () => {
+      const r = el.getBoundingClientRect();
+      if (r.top < window.innerHeight * 0.94 && r.bottom > 0) {
+        setState("in");
+        return true;
+      }
+      return false;
+    };
+    // Already on/near screen at mount — leave it visible (no entrance) so
+    // above-the-fold cards never flash empty and always render in captures.
+    if (check()) return;
+    // Below the fold: hide it now, invisibly, then animate it in on approach.
+    setState("out");
+
+    let io: IntersectionObserver | undefined;
+    const cleanup = () => {
+      io?.disconnect();
+      window.removeEventListener("scroll", onMove);
+      window.removeEventListener("resize", onMove);
+    };
+    function onMove() {
+      if (check()) cleanup();
+    }
+
+    if (typeof IntersectionObserver !== "undefined") {
+      io = new IntersectionObserver(() => { if (check()) cleanup(); }, {
+        rootMargin: "0px 0px -6% 0px",
+        threshold: 0.06,
+      });
+      io.observe(el);
+    }
+    // Fallback: some embedded/background renderers report the document hidden
+    // and never fire IntersectionObserver. Scroll + resize keep the reveal
+    // honest there, so content can't get stuck invisible.
+    window.addEventListener("scroll", onMove, { passive: true });
+    window.addEventListener("resize", onMove, { passive: true });
+    return cleanup;
+  }, [shown]);
+
+  return (
+    <div
+      ref={ref}
+      className={`reveal ${className ?? ""}`}
+      data-reveal={state === "idle" ? undefined : state}
+      style={delay ? { transitionDelay: `${delay}ms` } : undefined}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/docs/app/_components/runtime-signal-hero.tsx
+++ b/apps/docs/app/_components/runtime-signal-hero.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+
+import {
+  RuntimeSignalMap,
+  demoTopology,
+  type ServiceData,
+  type ConnectionData,
+} from "@/registry/backgrounds/runtime-signal-map";
+import { HeroContent, useHeroPlacement, type HeroCopy } from "./hero-frame";
+
+/* -------------------------------------------------------------------------
+ * The lead card of the homepage catalog grid (docs/61 §catalog). It is the one
+ * card the visitor can *drive*: the Runtime Signal Map rendered the way it is
+ * actually used — as a hero background with content over its safe area — plus a
+ * state HUD that patches real `services` health through the component's public
+ * API. Same card language as the rest of the grid (count chip, meta row with a
+ * go-arrow), but its controls are real buttons, so the shell is a <div> and only
+ * the title/arrow link out — never a whole-card link wrapping interactive
+ * elements.
+ * ---------------------------------------------------------------------- */
+
+const COPY: HeroCopy = {
+  eyebrow: "Signals live",
+  title: "Every request, drawn across your services.",
+  copy: "One request flows edge to database. Degraded and failed routes stay readable.",
+  primary: "Open dashboard",
+  secondary: "View services",
+};
+
+type Scenario = "nominal" | "degraded" | "incident";
+
+const SCENARIOS: { value: Scenario; label: string; tone: string }[] = [
+  { value: "nominal", label: "Nominal", tone: "var(--color-accent)" },
+  { value: "degraded", label: "Degraded", tone: "var(--color-warning)" },
+  { value: "incident", label: "Incident", tone: "var(--color-error)" },
+];
+
+/**
+ * Scenario overrides on the shipped demo topology — the same six services in
+ * three health states, driven through the public `services` / `connections`
+ * API. Mirrors the component playground's scenarios so the homepage and the
+ * docs demo can never drift apart.
+ */
+function scenarioTopology(scenario: Scenario): {
+  services: ServiceData[];
+  connections: ConnectionData[];
+} {
+  const { services, connections } = demoTopology();
+  const patch: Record<string, ServiceData["health"]> =
+    scenario === "nominal"
+      ? { payments: "healthy", queue: "healthy" }
+      : scenario === "degraded"
+        ? { payments: "healthy" }
+        : {};
+  const statusPatch: Record<string, string> =
+    scenario === "nominal"
+      ? { payments: "authorizing", queue: "drained" }
+      : scenario === "degraded"
+        ? { payments: "authorizing" }
+        : {};
+  return {
+    services: services.map((s) => ({
+      ...s,
+      health: patch[s.id] ?? s.health,
+      status: statusPatch[s.id] ?? s.status,
+    })),
+    connections,
+  };
+}
+
+export function RuntimeSignalHero({ count, href }: { count: number; href: string }) {
+  const [scenario, setScenario] = React.useState<Scenario>("nominal");
+  const placement = useHeroPlacement("left");
+  // "incident" is the component's built-in demo default — pass no services so
+  // its full demo extras render; the other scenarios patch health explicitly.
+  const topology = React.useMemo(
+    () => (scenario === "incident" ? null : scenarioTopology(scenario)),
+    [scenario],
+  );
+
+  return (
+    <div
+      className="group relative flex h-full flex-col overflow-hidden rounded-[22px] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-sm)] transition-all duration-300 hover:border-[color-mix(in_oklab,var(--fam)_45%,var(--color-border))] hover:shadow-[var(--shadow-md)]"
+      style={{ ["--fam" as string]: "#4f7cff" }}
+    >
+      <div className="relative flex-1 overflow-hidden border-b border-[var(--color-border)] bg-[var(--color-bg)]">
+        {/* showLabels off + eased density: on the homepage this is a *background*
+            carrying one state, not a diagnostic read-out. Health stays legible
+            through node treatment and the HUD; the labelled, full-density read
+            lives on the component page. */}
+        <RuntimeSignalMap
+          contentPlacement={placement}
+          services={topology?.services}
+          connections={topology?.connections}
+          showLabels={false}
+          density={0.85}
+          className="w-full"
+        >
+          <div className="pb-24 pt-14">
+            <HeroContent placement={placement} copy={COPY} minH="min-h-[520px] lg:min-h-[400px]" />
+          </div>
+        </RuntimeSignalMap>
+
+        {/* count chip — same position and treatment as every other card */}
+        <span
+          className="pointer-events-none absolute left-[15px] top-[15px] z-[3] inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold tabular-nums tracking-[0.04em]"
+          style={{
+            color: "var(--fam)",
+            background: "color-mix(in oklab, var(--fam) 13%, var(--color-surface))",
+            borderColor: "color-mix(in oklab, var(--fam) 32%, transparent)",
+          }}
+        >
+          {count} components
+        </span>
+
+        {/* state HUD — the one thing on this page you can drive */}
+        <div
+          className="absolute inset-x-4 bottom-4 z-[3] flex flex-wrap items-center gap-2"
+          role="group"
+          aria-label="Preview system state"
+        >
+          {SCENARIOS.map((s) => {
+            const on = s.value === scenario;
+            return (
+              <button
+                key={s.value}
+                type="button"
+                aria-pressed={on}
+                onClick={() => setScenario(s.value)}
+                className={`inline-flex h-[34px] items-center gap-2 rounded-full border px-3.5 text-[13px] font-semibold backdrop-blur transition-all ${
+                  on
+                    ? "text-[var(--color-fg)]"
+                    : "border-[var(--color-border-strong)] bg-[color-mix(in_oklab,var(--color-surface)_72%,transparent)] text-[var(--color-fg-secondary)] hover:bg-[color-mix(in_oklab,var(--color-surface)_90%,transparent)]"
+                }`}
+                style={
+                  on
+                    ? {
+                        borderColor: `color-mix(in oklab, ${s.tone} 62%, transparent)`,
+                        background: `color-mix(in oklab, ${s.tone} 16%, var(--color-surface))`,
+                        boxShadow: `0 0 20px color-mix(in oklab, ${s.tone} 22%, transparent)`,
+                      }
+                    : undefined
+                }
+              >
+                <span
+                  aria-hidden
+                  className="h-[7px] w-[7px] rounded-full transition-colors"
+                  style={on ? { background: s.tone, boxShadow: `0 0 9px ${s.tone}` } : { background: "var(--color-subtle)" }}
+                />
+                {s.label}
+              </button>
+            );
+          })}
+          <span className="ml-1 hidden text-[12px] text-[var(--color-subtle)] sm:inline">
+            ← your app sets this · Runtime Signal Map
+          </span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3.5 px-[19px] py-[17px]">
+        <span className="min-w-0">
+          <h3 className="text-[16.5px] font-semibold tracking-[-0.012em] text-[var(--color-fg)]">
+            <Link href={href} className="outline-none hover:text-[var(--color-accent-text)]">
+              Product backgrounds
+            </Link>
+          </h3>
+          <p className="mt-0.5 truncate text-[13.5px] text-[var(--color-muted)]">
+            Animated environments driven by your application state.
+          </p>
+        </span>
+        <Link
+          href={href}
+          aria-label="Browse product backgrounds"
+          className="ml-auto grid h-[38px] w-[38px] shrink-0 place-items-center rounded-full border border-[var(--color-border-strong)] text-[var(--color-muted)] transition-all duration-300 [transition-timing-function:cubic-bezier(0.2,0,0,1)] group-hover:-rotate-45 group-hover:border-[var(--color-accent)] group-hover:bg-[var(--color-accent)] group-hover:text-[var(--color-accent-fg)]"
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden>
+            <path d="M5 12h13M13 6l6 6-6 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/app/_components/sidebar-nav.tsx
+++ b/apps/docs/app/_components/sidebar-nav.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+
+/**
+ * Shared left-rail navigation language.
+ *
+ * Extracted from the component-docs sidebar so the /components browser rail is
+ * literally the same design rather than a lookalike: same row height, radius,
+ * type scale, count treatment, active tint and hover. Change it here and both
+ * rails move together.
+ */
+
+/** Disclosure chevron — points down when open, right when closed. */
+export function NavChevron({ open }: { open: boolean }) {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" className={open ? "" : "-rotate-90"} aria-hidden>
+      <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+/** Small uppercase heading above a group of rows. */
+export function NavGroupLabel({ children }: { children: ReactNode }) {
+  return (
+    <p className="mb-1.5 px-2.5 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-muted)]">
+      {children}
+    </p>
+  );
+}
+
+/** Top-level row: nav link, or a category with its count. */
+export const navRowClass = (active: boolean) =>
+  `flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-1.5 text-left font-medium ${
+    active
+      ? "bg-[color-mix(in_oklab,var(--color-accent)_12%,transparent)] text-[var(--color-accent-text)]"
+      : "text-[var(--color-fg)] hover:bg-[var(--color-bg-secondary)]"
+  }`;
+
+/** Nested row: an individual component beneath its category. */
+export const navChildClass = (active: boolean) =>
+  `block truncate rounded-md px-2 py-[5px] text-[13px] ${
+    active
+      ? "bg-[color-mix(in_oklab,var(--color-accent)_12%,transparent)] font-medium text-[var(--color-accent-text)]"
+      : "text-[var(--color-muted)] hover:bg-[var(--color-bg-secondary)] hover:text-[var(--color-fg)]"
+  }`;
+
+/** The hairline rail that indents a category's children. */
+export const navChildListClass = "mb-1 ml-4 border-l border-[var(--color-border)] pl-2";
+
+/** Count badge sitting at the end of a row. */
+export function NavCount({ children }: { children: ReactNode }) {
+  return <span className="text-[11.5px] tabular-nums text-[var(--color-muted)]">{children}</span>;
+}

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -123,6 +123,241 @@ input:focus-visible:not([data-noring]),
   background-size: 22px 22px;
 }
 
+/* ------------------------------------------------------------------ *
+ * Scroll reveal (docs/61 §catalog). Driven by the Reveal client component,
+ * which flips [data-reveal] once the element enters the viewport. Content is
+ * VISIBLE BY DEFAULT — only the explicit "out" state hides it — so a failed
+ * hydration or a no-JS agent can never leave the grid blank.
+ * ------------------------------------------------------------------ */
+.reveal {
+  transition:
+    opacity 0.62s cubic-bezier(0.2, 0, 0, 1),
+    transform 0.62s cubic-bezier(0.2, 0, 0, 1);
+}
+.reveal[data-reveal="out"] {
+  opacity: 0;
+  transform: translateY(20px) scale(0.985);
+}
+.reveal[data-reveal="in"] {
+  opacity: 1;
+  transform: none;
+}
+
+/* Card sheen — a slow diagonal light pass on hover, over the scene only. */
+.sheen::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+  background: linear-gradient(
+    115deg,
+    transparent 32%,
+    color-mix(in oklab, var(--color-fg) 9%, transparent) 46%,
+    transparent 60%
+  );
+  background-size: 260% 100%;
+  background-position: 120% 0;
+  transition: opacity 0.3s ease;
+}
+.group:hover .sheen::after {
+  opacity: 1;
+  animation: card-sheen 0.9s cubic-bezier(0.2, 0, 0, 1);
+}
+@keyframes card-sheen {
+  from {
+    background-position: 120% 0;
+  }
+  to {
+    background-position: -40% 0;
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Homepage category-scene micro-motion (docs/61 §catalog). One quiet loop per
+ * scene: a deploy stage sweeping, a collaborator's live ring, an upload bar,
+ * a card lifted mid-drag, a signal travelling an active path. The global
+ * reduced-motion rule below collapses every one to a static state.
+ * ------------------------------------------------------------------ */
+@keyframes cat-sweep {
+  from {
+    transform: translateX(-130%);
+  }
+  to {
+    transform: translateX(320%);
+  }
+}
+.cat-sweep {
+  animation: cat-sweep 1.6s linear infinite;
+}
+
+@keyframes cat-blink {
+  0%,
+  60%,
+  100% {
+    opacity: 0.3;
+  }
+  30% {
+    opacity: 1;
+  }
+}
+.cat-blink {
+  animation: cat-blink 1.5s infinite;
+}
+
+@keyframes cat-ring {
+  0% {
+    transform: scale(0.7);
+    opacity: 0.8;
+  }
+  70%,
+  100% {
+    transform: scale(1.15);
+    opacity: 0;
+  }
+}
+.cat-ring {
+  animation: cat-ring 2.4s ease-out infinite;
+}
+
+@keyframes cat-grow {
+  0% {
+    width: 12%;
+  }
+  65% {
+    width: 78%;
+  }
+  100% {
+    width: 12%;
+  }
+}
+.cat-grow {
+  animation: cat-grow 3s cubic-bezier(0.2, 0, 0, 1) infinite;
+}
+
+@keyframes cat-lift {
+  0%,
+  100% {
+    transform: rotate(-3deg) translateY(-4px);
+  }
+  50% {
+    transform: rotate(-2deg) translateY(-7px);
+  }
+}
+.cat-lift {
+  animation: cat-lift 3s ease-in-out infinite;
+}
+
+@keyframes cat-flow {
+  to {
+    stroke-dashoffset: -48;
+  }
+}
+.cat-flow {
+  animation: cat-flow 2.4s linear infinite;
+}
+
+/* ------------------------------------------------------------------ *
+ * Homepage pack "product shot" micro-motion (docs/61 §packs). Static skeleton
+ * regions inside each pack window get one quiet loop each — streamed answer
+ * lines, ticking logs, arriving table rows, a breathing active pipeline stage.
+ * The global reduced-motion rule below collapses all of them to a static shot.
+ * ------------------------------------------------------------------ */
+@keyframes pack-type {
+  0%,
+  22% {
+    transform: scaleX(0);
+    opacity: 0;
+  }
+  40%,
+  88% {
+    transform: scaleX(1);
+    opacity: 1;
+  }
+  100% {
+    transform: scaleX(1);
+    opacity: 0;
+  }
+}
+.pack-type > [data-ln] {
+  transform-origin: left;
+  animation: pack-type 4s ease-out infinite;
+}
+.pack-type > [data-ln]:nth-child(2) {
+  animation-delay: 0.25s;
+}
+.pack-type > [data-ln]:nth-child(3) {
+  animation-delay: 0.5s;
+}
+.pack-type > [data-ln]:nth-child(4) {
+  animation-delay: 0.75s;
+}
+.pack-type > [data-ln]:nth-child(5) {
+  animation-delay: 1s;
+}
+
+@keyframes pack-logfade {
+  0% {
+    opacity: 0.25;
+  }
+  15% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.55;
+  }
+}
+.pack-logs > [data-ln] {
+  animation: pack-logfade 2.8s linear infinite;
+}
+.pack-logs > [data-ln]:nth-child(2) {
+  animation-delay: 0.4s;
+}
+.pack-logs > [data-ln]:nth-child(3) {
+  animation-delay: 0.8s;
+}
+.pack-logs > [data-ln]:nth-child(4) {
+  animation-delay: 1.2s;
+}
+
+@keyframes pack-rowin {
+  0% {
+    transform: translateX(-6px);
+    opacity: 0;
+  }
+  18%,
+  100% {
+    transform: none;
+    opacity: 1;
+  }
+}
+.pack-rows > [data-ln] {
+  animation: pack-rowin 3.2s cubic-bezier(0.2, 0, 0, 1) infinite;
+}
+.pack-rows > [data-ln]:nth-child(2) {
+  animation-delay: 0.3s;
+}
+.pack-rows > [data-ln]:nth-child(3) {
+  animation-delay: 0.6s;
+}
+.pack-rows > [data-ln]:nth-child(4) {
+  animation-delay: 0.9s;
+}
+
+@keyframes pack-blink {
+  0%,
+  60%,
+  100% {
+    opacity: 0.3;
+  }
+  30% {
+    opacity: 1;
+  }
+}
+.pack-blink {
+  animation: pack-blink 1.5s infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -131,5 +366,13 @@ input:focus-visible:not([data-noring]),
     animation-iteration-count: 1 !important;
     transition-duration: 0.001ms !important;
     scroll-behavior: auto !important;
+  }
+  /* No rise-and-fade entrance: the grid is simply present from the start. */
+  .reveal[data-reveal="out"] {
+    opacity: 1;
+    transform: none;
+  }
+  .sheen::after {
+    display: none;
   }
 }

--- a/apps/docs/app/packs/[slug]/page.tsx
+++ b/apps/docs/app/packs/[slug]/page.tsx
@@ -26,9 +26,9 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   return pageMetadata({ title: pack.name, description: pack.tagline, path: `/packs/${pack.slug}`, type: "article" });
 }
 
-function Section({ title, sub, children }: { title: string; sub?: string; children: React.ReactNode }) {
+function Section({ title, sub, children, id }: { title: string; sub?: string; children: React.ReactNode; id?: string }) {
   return (
-    <section className="border-t border-[var(--color-border)] py-9">
+    <section id={id} className="scroll-mt-24 border-t border-[var(--color-border)] py-9">
       <h2 className="text-xl font-semibold tracking-tight text-[var(--color-fg)]">{title}</h2>
       {sub ? <p className="mt-1 mb-4 max-w-2xl text-[14px] text-[var(--color-muted)]">{sub}</p> : <div className="mb-4" />}
       {children}
@@ -106,13 +106,18 @@ export default async function PackPage({ params }: { params: Promise<{ slug: str
           <span className="text-[13px] text-[var(--color-muted)]">Editable source · accessible · reduced-motion safe</span>
         </div>
 
+        {/* In the free/open catalog `packPrimaryCta` degrades to the same
+            "Explore components" → #included CTA this row used to hardcode, which
+            rendered the identical button twice. Pair it with the install jump
+            instead; when commerce is on (buy / waitlist) the primary differs and
+            "Explore components" is the right companion. */}
         <div className="mt-6 flex flex-wrap items-center gap-4">
           <AccessCta cta={primary} />
           <Link
-            href="#included"
+            href={primary.kind === "explore-components" ? "#install" : "#included"}
             className="inline-flex items-center rounded-lg border border-[var(--color-border)] px-4 py-2.5 text-[14px] font-medium text-[var(--color-fg)] transition-colors hover:bg-[var(--color-bg-secondary)]"
           >
-            Explore components
+            {primary.kind === "explore-components" ? "Install this pack" : "Explore components"}
           </Link>
         </div>
       </header>
@@ -207,7 +212,7 @@ export default async function PackPage({ params }: { params: Promise<{ slug: str
       </Section>
 
       {/* INSTALLATION */}
-      <Section title="Installation" sub={`Installs ${filesInstalled} source files into your repo - you own them after install.`}>
+      <Section id="install" title="Installation" sub={`Installs ${filesInstalled} source files into your repo - you own them after install.`}>
         <p className="mb-3 text-[13px] text-[var(--color-muted)]">
           Install with the shadcn CLI - no account, no config. Every command below works as-is.
         </p>

--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -4,19 +4,29 @@ import Link from "next/link";
 import { product } from "../lib/product";
 import { absoluteUrl } from "../lib/seo";
 import { AiResponseStream, type ResponseSegment } from "@/registry/ai/ai-response-stream";
-import { featuredItems, categoryCount, bySlug, packSpans, SPAN_CLASS, resolvePresentation, componentItems, blockItems, type CatalogItem } from "../lib/catalog";
+import { categories, categoryCount, bySlug, SPAN_CLASS, componentItems, blockItems, type CatalogItem, type CardSpan, type Category, type CategoryId } from "../lib/catalog";
 import { packs, type Pack } from "../lib/packs";
 import { statusLabel } from "../lib/commerce";
 import { fundingConfig } from "../lib/funding";
-import { CatalogPreview } from "./_previews";
-import { RuntimeSignalMapHeroPreview } from "./_previews/catalog/runtime-signal-map-hero";
-import { CatalogStage } from "./_components/catalog-stage";
+import { installCommand } from "../lib/product";
+import {
+  AmbientScene,
+  CollaborationScene,
+  DeveloperScene,
+  FileScene,
+  HeroBlockScene,
+  ProductivityScene,
+  SecurityScene,
+  TextScene,
+} from "./_components/category-scenes";
 import { FundingPipeline } from "./_components/funding-pipeline";
 import { StarButton } from "./_components/github-star";
 import { GoldSponsors } from "./_components/gold-sponsors";
-import { LazyPreview } from "./_components/lazy-preview";
+import { InstallChip } from "./_components/install-chip";
 import { HeroShowcase } from "./_components/hero-showcase";
+import { Reveal } from "./_components/reveal";
 import { PageView } from "./_components/page-view";
+import { MediaGalleryHero } from "./_components/media-gallery-hero";
 
 /* ------------------------------------------------------------------ *
  * Homepage art-direction (docs/59). Seven distinct sections, one visual
@@ -29,23 +39,33 @@ import { PageView } from "./_components/page-view";
 // Controlled per-family accent palette — one hue per workflow family, used only
 // on card chrome (icon, count pill, explore link, hover ring). Shared design
 // system; distinct color so families are visually separable at a glance.
-type Family = {
-  cat: string;
-  name: string;
-  value: string;
-  icon: string;
-  c: string;
+/* Per-category identity — one accent + one glyph for every catalog category.
+   Single source of truth: the showcase cards above and the browse index below
+   both read from it, so a category looks the same wherever it appears. Accents
+   stay inside the brand-adjacent range (azure / cyan / teal / emerald / sky /
+   indigo / amber / coral / slate); purple is retired. */
+const CATEGORY_META: Record<CategoryId, { c: string; icon: string }> = {
+  ai: { c: "#4f7cff", icon: "M12 3l1.8 4.7L18.5 9l-4.7 1.3L12 15l-1.8-4.7L5.5 9l4.7-1.3zM18 15l.9 2.3L21 18l-2.1.7L18 21l-.9-2.3L15 18l2.1-.7z" },
+  "developer-tools": { c: "#3e5ae8", icon: "M5 6l6 6-6 6M13 18h6" },
+  collaboration: { c: "#22c7d9", icon: "M9 11a3 3 0 100-6 3 3 0 000 6zM3 20a6 6 0 0112 0M17 11a3 3 0 10-2-5.2M15.5 14.5A6 6 0 0121 20" },
+  "data-motion": { c: "#14b8a6", icon: "M5 20V11M12 20V4M19 20v-6" },
+  mobile: { c: "#0ea5e9", icon: "M8 3h8a1 1 0 011 1v16a1 1 0 01-1 1H8a1 1 0 01-1-1V4a1 1 0 011-1zM11 18h2" },
+  file: { c: "#38bdf8", icon: "M6 3h9l4 4v14H6zM14 3v5h5M9 13h6M9 17h4" },
+  commerce: { c: "#10b981", icon: "M4 6h15l-1.6 8.5a2 2 0 01-2 1.6H8.6a2 2 0 01-2-1.7L4.7 4.6A1 1 0 003.7 4H2M8 20a1 1 0 100-2 1 1 0 000 2zM17 20a1 1 0 100-2 1 1 0 000 2z" },
+  security: { c: "#6366f1", icon: "M12 3l7 3v5c0 5-3.5 8-7 9-3.5-1-7-4-7-9V6zM9 12l2 2 4-4" },
+  communication: { c: "#2dd4bf", icon: "M4 5h16v10H9l-5 4V5zM8 10h.01M12 10h.01M16 10h.01" },
+  productivity: { c: "#f59e0b", icon: "M4 4h5v16H4zM10 4h4v10h-4zM15 4h5v7h-5z" },
+  text: { c: "#e0b341", icon: "M4 7V5h16v2M12 5v14M9 19h6" },
+  creative: { c: "#fb7185", icon: "M4 5h16v6H4zM4 14h10v5H4zM16 14h4v5h-4z" },
+  cursor: { c: "#f59e0b", icon: "M5 3l14 8-6 1.5L9.5 19z" },
+  media: { c: "#22c7d9", icon: "M4 5h16v14H4zM4 15l4-4 4 4 3-3 5 5M9 9.5a1 1 0 100-2 1 1 0 000 2z" },
+  scroll: { c: "#6366f1", icon: "M12 4v13M7 12l5 5 5-5M5 20h14" },
+  backgrounds: { c: "#ff6b5e", icon: "M3 11c3-4 6-4 9 0s6 4 9 0M3 16c3-4 6-4 9 0s6 4 9 0M3 6c3-4 6-4 9 0s6 4 9 0" },
+  "product-backgrounds": { c: "#4f7cff", icon: "M5 7l7 5 7-5M5 17l7-5 7 5M5 7v10M19 7v10" },
+  "workflow-heroes": { c: "#22c7d9", icon: "M4 5h16v6H4zM4 14h7v5H4zM13 14h7v5h-7z" },
+  "animated-shadcn": { c: "#94a3b8", icon: "M4 4h16v16H4zM4 10h16M10 10v10" },
+  icons: { c: "#f6b94a", icon: "M12 3l2.2 5.3L20 10l-5.8 1.7L12 17l-2.2-5.3L4 10l5.8-1.7z" },
 };
-const FAMILIES: Family[] = [
-  { cat: "ai", name: "AI workspace", value: "Streaming responses, agent runs, and tool activity.", c: "#4f7cff", icon: "M12 3l1.8 4.7L18.5 9l-4.7 1.3L12 15l-1.8-4.7L5.5 9l4.7-1.3zM18 15l.9 2.3L21 18l-2.1.7L18 21l-.9-2.3L15 18l2.1-.7z" },
-  { cat: "developer-tools", name: "Developer console", value: "Pipelines, logs, inspectors, and environments.", c: "#3e5ae8", icon: "M5 6l6 6-6 6M13 18h6" },
-  { cat: "collaboration", name: "Collaboration", value: "Presence, approvals, comments, and activity.", c: "#22c7d9", icon: "M9 11a3 3 0 100-6 3 3 0 000 6zM3 20a6 6 0 0112 0M17 11a3 3 0 10-2-5.2M15.5 14.5A6 6 0 0121 20" },
-  { cat: "data-motion", name: "Data motion", value: "KPIs, refresh states, and streaming tables.", c: "#14b8a6", icon: "M5 20V11M12 20V4M19 20v-6" },
-  { cat: "commerce", name: "Commerce", value: "Variants, cart, and checkout flows.", c: "#10b981", icon: "M4 6h15l-1.6 8.5a2 2 0 01-2 1.6H8.6a2 2 0 01-2-1.7L4.7 4.6A1 1 0 003.7 4H2M8 20a1 1 0 100-2 1 1 0 000 2zM17 20a1 1 0 100-2 1 1 0 000 2z" },
-  { cat: "security", name: "Security", value: "Passkeys, two-factor, and session safety.", c: "#6366f1", icon: "M12 3l7 3v5c0 5-3.5 8-7 9-3.5-1-7-4-7-9V6zM9 12l2 2 4-4" },
-  { cat: "productivity", name: "Productivity", value: "Boards, timelines, and dependencies.", c: "#f59e0b", icon: "M4 4h5v16H4zM10 4h4v10h-4zM15 4h5v7h-5z" },
-  { cat: "text", name: "Text & creative", value: "Kinetic text, cards, and backgrounds.", c: "#ff6b5e", icon: "M4 7V5h16v2M12 5v14M9 19h6" },
-];
 
 const categoryHref = (cat: string) => `/components?category=${cat}`;
 
@@ -65,70 +85,234 @@ const DIFFERENTIATORS = [
   { t: "Composed blocks", d: "Four components compose into one installable, app-owned workflow block.", icon: "M4 4h7v7H4zM13 13h7v7h-7zM13 4h7v7h-7z" },
 ];
 
-/* ---- Featured component card (lean, editorial) ---- */
-function FeaturedCard({ item, wide }: { item: CatalogItem; wide?: boolean }) {
-  const p = resolvePresentation(item);
-  const stage = (
-    <CatalogStage size={p.previewSize} family={p.stageFamily} ambient={p.previewMode === "ambient"} mobileFrame={p.previewSize === "mobile"}>
-      <CatalogPreview id={item.id} />
-    </CatalogStage>
-  );
-  const preview =
-    p.previewSize === "full" || p.previewSize === "wide" || p.previewSize === "mobile" ? (
-      <LazyPreview label={`${item.name} preview`} minHeightClass="min-h-[300px]">
-        {stage}
-      </LazyPreview>
-    ) : (
-      stage
-    );
-
-  const meta = (
-    <div className={`flex flex-col ${wide ? "justify-center gap-3 p-6 lg:p-8" : "gap-2 p-5"}`}>
-      <div className="flex items-center gap-2.5">
-        <h3 className={`font-semibold tracking-tight text-[var(--color-fg)] ${wide ? "text-[22px]" : "text-[17px]"}`}>
-          <Link href={item.documentationPath} className="outline-none after:absolute after:inset-0 after:rounded-3xl hover:text-[var(--color-accent-text)]">
-            {item.name}
-          </Link>
-        </h3>
-        <FeaturedPill featured={item.featured} />
+/* ---- Shared section header (docs/61) — keyline eyebrow + balanced title on
+        the left, one quiet bordered CTA button bottom-aligned on the right. ---- */
+function SectionHead({
+  eyebrow,
+  signature,
+  title,
+  desc,
+  href,
+  cta,
+}: {
+  eyebrow: string;
+  /** Coral keyline for the one commercial "ship faster" moment. */
+  signature?: boolean;
+  title: string;
+  desc: ReactNode;
+  href: string;
+  cta: string;
+}) {
+  const tone = signature ? "text-[var(--color-signature-text)]" : "text-[var(--color-accent-text)]";
+  const line = signature ? "bg-[var(--color-signature)]" : "bg-[var(--color-accent)]";
+  return (
+    <div className="mb-10 flex flex-wrap items-end justify-between gap-6">
+      <div className="max-w-[660px]">
+        <p className={`inline-flex items-center gap-2.5 text-[12.5px] font-semibold uppercase tracking-[0.12em] ${tone}`}>
+          <span aria-hidden className={`h-[1.5px] w-[22px] rounded-full ${line}`} />
+          {eyebrow}
+        </p>
+        <h2 className="mt-3 text-balance text-[clamp(1.8rem,3.4vw,2.75rem)] font-semibold leading-[1.06] tracking-[-0.023em] text-[var(--color-fg)]">
+          {title}
+        </h2>
+        <p className="mt-3.5 max-w-[58ch] text-[15.5px] leading-relaxed text-[var(--color-muted)]">{desc}</p>
       </div>
-      <p className={`text-[var(--color-muted)] ${wide ? "max-w-md text-[15px] leading-relaxed" : "line-clamp-2 text-[13.5px] leading-relaxed"}`}>
-        {item.description.split(" - ")[0].split(". ")[0]}.
-      </p>
-      <span className="mt-1 inline-flex items-center gap-1 text-[13.5px] font-medium text-[var(--color-accent-text)]">
-        Open component →
+      <Link
+        href={href}
+        className="group inline-flex h-[42px] shrink-0 items-center gap-2 rounded-xl border border-[var(--color-border-strong)] bg-[var(--color-surface)] px-5 text-[14px] font-semibold text-[var(--color-fg)] shadow-[var(--shadow-sm)] transition-colors hover:border-[var(--color-accent)] hover:bg-[var(--color-surface-hover)]"
+      >
+        {cta}
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden className="transition-transform duration-200 group-hover:translate-x-[3px]">
+          <path d="M5 12h13M13 6l6 6-6 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </Link>
+    </div>
+  );
+}
+
+/* ---- Section atmosphere — the hero's lit-studio language (azure spotlight,
+        cyan counter-glow, edge-light, masked dot lattice), echoed per band. ---- */
+function SectionAtmo({ dots, counter }: { dots?: boolean; counter?: boolean }) {
+  return (
+    <div aria-hidden className="pointer-events-none absolute inset-0 -z-10">
+      <div className="absolute inset-0" style={{ background: "radial-gradient(48% 46% at 85% -6%, var(--color-spotlight), transparent 64%)" }} />
+      {counter ? (
+        <div className="absolute inset-0" style={{ background: "radial-gradient(36% 40% at 4% 100%, var(--color-secondary-accent-soft), transparent 60%)" }} />
+      ) : null}
+      <div
+        className="absolute inset-x-0 top-0 h-px"
+        style={{ background: "linear-gradient(to right, transparent, color-mix(in oklab, var(--color-accent) 42%, transparent), transparent)" }}
+      />
+      {dots ? (
+        <div
+          className="absolute inset-0 opacity-[0.55]"
+          style={{
+            backgroundImage: "radial-gradient(circle at 1px 1px, color-mix(in oklab, var(--color-fg) 7%, transparent) 1px, transparent 0)",
+            backgroundSize: "28px 28px",
+            WebkitMaskImage: "radial-gradient(110% 70% at 80% 0%, #000, transparent 62%)",
+            maskImage: "radial-gradient(110% 70% at 80% 0%, #000, transparent 62%)",
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ *
+ * Catalog category card (docs/61). The homepage sells CATEGORIES, not single
+ * components: each card carries one simplified scene standing for that
+ * category's work, its live component count, and links straight to the
+ * filtered catalog. Full live previews live on the category and component
+ * pages, where there is room to read them.
+ * ------------------------------------------------------------------ */
+type CategoryCardSpec = {
+  cat: CategoryId;
+  label: string;
+  value: string;
+  accent: string;
+  scene: ReactNode;
+  span?: CardSpan;
+  /** Full-bleed scenes (backgrounds/heroes) skip the panel padding + lattice. */
+  bleed?: boolean;
+  minH?: string;
+};
+
+function CategoryCard({ cat, label, value, accent, scene, bleed, minH = "min-h-[250px]" }: CategoryCardSpec) {
+  return (
+    <Link
+      href={categoryHref(cat)}
+      className="group relative flex h-full flex-col overflow-hidden rounded-[22px] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-sm)] transition-all duration-300 hover:-translate-y-1 hover:border-[color-mix(in_oklab,var(--fam)_45%,var(--color-border))] hover:shadow-[var(--shadow-md)]"
+      style={{ ["--fam" as string]: accent }}
+    >
+      <div
+        className={`sheen relative flex-1 overflow-hidden border-b border-[var(--color-border)] ${minH} ${
+          bleed ? "" : "grid place-items-center px-[26px] pb-[26px] pt-[30px]"
+        }`}
+        style={{
+          background:
+            "radial-gradient(100% 100% at 50% 0%, color-mix(in oklab, var(--fam) 9%, transparent), transparent 72%), var(--color-bg-elevated)",
+        }}
+      >
+        {bleed ? null : (
+          <span
+            aria-hidden
+            className="absolute inset-0 opacity-50"
+            style={{
+              backgroundImage:
+                "radial-gradient(circle at 1px 1px, color-mix(in oklab, var(--color-fg) 8%, transparent) 1px, transparent 0)",
+              backgroundSize: "20px 20px",
+              WebkitMaskImage: "radial-gradient(90% 90% at 50% 0%, #000, transparent 82%)",
+              maskImage: "radial-gradient(90% 90% at 50% 0%, #000, transparent 82%)",
+            }}
+          />
+        )}
+        {scene}
+        <span
+          className="absolute left-[15px] top-[15px] z-[3] inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold tabular-nums tracking-[0.04em]"
+          style={{
+            color: "var(--fam)",
+            background: "color-mix(in oklab, var(--fam) 13%, var(--color-surface))",
+            borderColor: "color-mix(in oklab, var(--fam) 32%, transparent)",
+          }}
+        >
+          {categoryCount(cat)} components
+        </span>
+      </div>
+      <div className="flex items-center gap-3.5 px-[19px] py-[17px]">
+        <span className="min-w-0">
+          <h3 className="text-[16.5px] font-semibold tracking-[-0.012em] text-[var(--color-fg)] transition-colors group-hover:text-[var(--color-accent-text)]">
+            {label}
+          </h3>
+          <p className="mt-0.5 truncate text-[13.5px] text-[var(--color-muted)]">{value}</p>
+        </span>
+        <span
+          aria-hidden
+          className="ml-auto grid h-[38px] w-[38px] shrink-0 place-items-center rounded-full border border-[var(--color-border-strong)] text-[var(--color-muted)] transition-all duration-300 [transition-timing-function:cubic-bezier(0.2,0,0,1)] group-hover:-rotate-45 group-hover:border-[var(--color-accent)] group-hover:bg-[var(--color-accent)] group-hover:text-[var(--color-accent-fg)]"
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none">
+            <path d="M5 12h13M13 6l6 6-6 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </span>
+      </div>
+    </Link>
+  );
+}
+
+/* ------------------------------------------------------------------ *
+ * Browse-index card (docs/61 §index). The showcase above previews nine
+ * categories at full size; this is the COMPLETE index — every category, in a
+ * denser icon-led card so the two grids never read as the same thing. Cards
+ * rise in on scroll and answer to hover: accent rail, lifting glyph, sheen,
+ * and a chevron that slides out of the label.
+ * ------------------------------------------------------------------ */
+function CategoryIndexCard({ cat }: { cat: Category }) {
+  const meta = CATEGORY_META[cat.id];
+  return (
+    <Link
+      href={categoryHref(cat.id)}
+      className="group sheen relative flex h-full flex-col overflow-hidden rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-[var(--shadow-sm)] transition-all duration-300 [transition-timing-function:cubic-bezier(0.2,0,0,1)] hover:-translate-y-1 hover:border-[color-mix(in_oklab,var(--fam)_50%,var(--color-border))] hover:shadow-[var(--shadow-md)]"
+      style={{ ["--fam" as string]: meta.c }}
+    >
+      {/* accent rail draws in from the left on hover */}
+      <span
+        aria-hidden
+        className="absolute inset-x-0 top-0 h-[2px] origin-left scale-x-0 transition-transform duration-300 [transition-timing-function:cubic-bezier(0.2,0,0,1)] group-hover:scale-x-100"
+        style={{ background: "linear-gradient(to right, var(--fam), transparent)" }}
+      />
+
+      <span className="flex items-start justify-between gap-2">
+        <span
+          aria-hidden
+          className="grid h-10 w-10 place-items-center rounded-xl transition-transform duration-300 [transition-timing-function:cubic-bezier(0.2,0,0,1)] group-hover:-translate-y-0.5 group-hover:scale-110"
+          style={{
+            color: "var(--fam)",
+            background: "color-mix(in oklab, var(--fam) 14%, transparent)",
+            border: "1px solid color-mix(in oklab, var(--fam) 30%, transparent)",
+          }}
+        >
+          <svg width="19" height="19" viewBox="0 0 24 24" fill="none">
+            <path d={meta.icon} stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </span>
+        <span
+          className="rounded-full px-2 py-0.5 text-[11.5px] font-bold tabular-nums transition-colors"
+          style={{ color: "var(--fam)", background: "color-mix(in oklab, var(--fam) 13%, transparent)" }}
+        >
+          {categoryCount(cat.id)}
+        </span>
       </span>
-    </div>
-  );
 
-  return (
-    <div className="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-sm)] ring-1 ring-transparent transition-all duration-300 hover:-translate-y-0.5 hover:border-[color-mix(in_oklab,var(--color-accent)_35%,var(--color-border))] hover:shadow-[var(--shadow-md)] hover:ring-[color-mix(in_oklab,var(--color-accent)_18%,transparent)]">
-      {wide ? (
-        <div className="grid lg:grid-cols-[1.35fr_0.65fr]">
-          <div className="min-w-0 border-b border-[var(--color-border)] lg:border-b-0 lg:border-r">{preview}</div>
-          {meta}
-        </div>
-      ) : (
-        <>
-          <div className="border-b border-[var(--color-border)]">{preview}</div>
-          {meta}
-        </>
-      )}
-    </div>
+      <h3 className="mt-3.5 flex items-center gap-1 text-[14.5px] font-semibold tracking-[-0.01em] text-[var(--color-fg)] transition-colors group-hover:text-[var(--fam)]">
+        {cat.label}
+        <svg
+          width="13"
+          height="13"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden
+          className="-translate-x-1 opacity-0 transition-all duration-300 [transition-timing-function:cubic-bezier(0.2,0,0,1)] group-hover:translate-x-0 group-hover:opacity-100"
+        >
+          <path d="M5 12h13M13 6l6 6-6 6" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </h3>
+      <p className="mt-1 line-clamp-2 text-[12.5px] leading-relaxed text-[var(--color-muted)]">{cat.blurb}</p>
+    </Link>
   );
 }
 
-function FeaturedPill({ featured }: { featured: boolean }) {
-  if (!featured) return null;
-  return (
-    <span className="inline-flex items-center gap-1 rounded-full bg-[var(--color-accent-soft)] px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-accent-text)]">
-      <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-        <path d="M12 2l2.9 6.26L22 9.27l-5 4.87L18.18 22 12 18.56 5.82 22 7 14.14l-5-4.87 7.1-1.01L12 2z" />
-      </svg>
-      Featured
-    </span>
-  );
-}
+/* One unified grid (docs/61 §catalog): every catalog family the homepage
+   showcases, in bento order — 8+4 / 4+4+4 / 6+6 / 12. The interactive
+   product-backgrounds lead card is rendered separately above these. */
+const CATALOG_CARDS: CategoryCardSpec[] = [
+  { cat: "developer-tools", label: "Developer console", value: "Pipelines, logs, inspectors, and environments.", accent: "#3e5ae8", span: 8, scene: <DeveloperScene /> },
+  { cat: "collaboration", label: "Collaboration", value: "Presence, approvals, and activity.", accent: "#22c7d9", span: 4, scene: <CollaborationScene /> },
+  { cat: "file", label: "File workflows", value: "Upload, queue, and processing.", accent: "#38bdf8", span: 4, scene: <FileScene /> },
+  { cat: "security", label: "Security & accounts", value: "Passkeys, two-factor, and sessions.", accent: "#6366f1", span: 4, scene: <SecurityScene /> },
+  { cat: "productivity", label: "Productivity", value: "Boards, timelines, and dependencies.", accent: "#f59e0b", span: 4, scene: <ProductivityScene /> },
+  { cat: "workflow-heroes", label: "Workflow heroes", value: "Hero blocks around a real workflow.", accent: "#22c7d9", span: 6, scene: <HeroBlockScene />, bleed: true, minH: "min-h-[210px]" },
+  { cat: "backgrounds", label: "Ambient backgrounds", value: "Quiet, performance-safe texture and light.", accent: "#ff6b5e", span: 6, scene: <AmbientScene />, bleed: true, minH: "min-h-[210px]" },
+  { cat: "text", label: "Text animations", value: "Headline-grade reveals, scrambles, and loops.", accent: "#e0b341", span: 12, scene: <TextScene />, minH: "min-h-[240px]" },
+];
 
 /* ---- Hero product-proof stat tile (truthful, catalog-derived — never fake trust) ---- */
 function ProofStat({ value, label }: { value: ReactNode; label: string }) {
@@ -164,113 +348,314 @@ function StrengthChip({ path, children }: { path: string; children: ReactNode })
   );
 }
 
-/* ---- Workflow category tile (bold family-colored cover) ---- */
-function CategoryTile({ f }: { f: Family }) {
-  const n = categoryCount(f.cat as never);
+/* ------------------------------------------------------------------ *
+ * Pack card (docs/61) — a product shot of the composed block. A browser-frame
+ * window renders the block's real workspace layout with its four components as
+ * numbered regions, a legend maps numbers to component names, and the footer
+ * carries the real one-command install. Identity first; no staircase list.
+ * ------------------------------------------------------------------ */
+
+type ShotArt = { c: string; icon: string; addr: string; grid: React.CSSProperties; blockNote: string };
+const PACK_ART: Record<string, ShotArt> = {
+  "ai-interface": {
+    c: "#4f7cff",
+    icon: "M12 3l1.8 4.7L18.5 9l-4.7 1.3L12 15l-1.8-4.7L5.5 9l4.7-1.3zM18 15l.9 2.3L21 18l-2.1.7L18 21l-.9-2.3L15 18l2.1-.7z",
+    addr: "yourapp.com/agent",
+    grid: { gridTemplateColumns: "96px 1fr 92px", gridTemplateRows: "1fr 46px", gridTemplateAreas: '"ra rb rc" "ra rd rc"' },
+    blockNote: "app-controlled state",
+  },
+  "developer-tools": {
+    c: "#3e5ae8",
+    icon: "M5 6l6 6-6 6M13 18h6",
+    addr: "yourapp.com/deploys",
+    grid: { gridTemplateColumns: "1.15fr 1fr", gridTemplateRows: "34px 56px 1fr", gridTemplateAreas: '"ra ra" "rb rb" "rc rd"' },
+    blockNote: "provider-neutral",
+  },
+  collaboration: {
+    c: "#22c7d9",
+    icon: "M9 11a3 3 0 100-6 3 3 0 000 6zM3 20a6 6 0 0112 0M17 11a3 3 0 10-2-5.2M15.5 14.5A6 6 0 0121 20",
+    addr: "yourapp.com/reviews/128",
+    grid: { gridTemplateColumns: "1fr 108px", gridTemplateRows: "36px 1fr 42px", gridTemplateAreas: '"ra ra" "rc rb" "rd rb"' },
+    blockNote: "your users & permissions",
+  },
+  "data-motion": {
+    c: "#14b8a6",
+    icon: "M5 20V11M12 20V4M19 20v-6",
+    addr: "yourapp.com/ops",
+    grid: { gridTemplateColumns: "1fr 1fr", gridTemplateRows: "58px 34px 1fr", gridTemplateAreas: '"ra ra" "rb rc" "rd rd"' },
+    blockNote: "no charting library",
+  },
+};
+
+/* Skeleton atoms for the window regions. `Ln` renders `[data-ln]` so the
+   pack-type / pack-logs / pack-rows loops in globals.css can address lines. */
+function Ln({ w, dim, fam, ml }: { w: string; dim?: boolean; fam?: boolean; ml?: string }) {
   return (
-    <Link
-      href={categoryHref(f.cat)}
-      className="group relative flex flex-col overflow-hidden rounded-3xl border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-sm)] transition-all hover:-translate-y-0.5 hover:shadow-[var(--shadow-md)]"
-      style={{ ["--fam" as string]: f.c }}
+    <div
+      data-ln
+      className="mb-[5px] h-[5px] rounded-[4px] last:mb-0"
+      style={{
+        width: w,
+        marginLeft: ml,
+        background: fam
+          ? "color-mix(in oklab, var(--fam) 45%, transparent)"
+          : dim
+            ? "color-mix(in oklab, var(--color-fg) 7%, transparent)"
+            : "color-mix(in oklab, var(--color-fg) 13%, transparent)",
+      }}
+    />
+  );
+}
+function MPill({ w, h = 12, on, round, className, style }: { w: number | string; h?: number; on?: boolean; round?: boolean; className?: string; style?: React.CSSProperties }) {
+  return (
+    <span
+      className={className}
+      style={{
+        display: "inline-block",
+        width: w,
+        height: h,
+        borderRadius: round ? "50%" : 99,
+        background: on ? "color-mix(in oklab, var(--fam) 45%, transparent)" : "color-mix(in oklab, var(--color-fg) 9%, transparent)",
+        ...style,
+      }}
+    />
+  );
+}
+function ShotRegion({ area, n, label, children, className }: { area: string; n: number; label: string; children?: ReactNode; className?: string }) {
+  return (
+    <div
+      className={`relative min-h-0 min-w-0 overflow-hidden rounded-[9px] border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 pb-2 pt-6 ${className ?? ""}`}
+      style={{ gridArea: area }}
     >
-      {/* Family cover — restrained: a top-border accent + a SOFT top-down tint +
-          a colored glyph chip. The family colour reads through the icon, border,
-          and a faint wash only — never a filled colour panel (cool identity rule). */}
-      <div
-        className="relative flex h-[136px] items-center justify-center overflow-hidden border-t-2"
-        style={{
-          borderTopColor: "var(--fam)",
-          background: "radial-gradient(120% 120% at 50% 0%, color-mix(in oklab, var(--fam) 13%, var(--color-surface)) 0%, var(--color-surface) 72%)",
-        }}
-        aria-hidden
+      <span
+        className="absolute left-[7px] top-[6px] inline-flex max-w-[calc(100%-14px)] items-center gap-[5px] rounded-[5px] px-1.5 py-[2px] text-[8.5px] font-bold uppercase tracking-[0.05em]"
+        style={{ color: "var(--fam)", background: "color-mix(in oklab, var(--fam) 13%, transparent)" }}
       >
-        <div
-          className="absolute inset-0 opacity-[0.3]"
-          style={{ backgroundImage: "radial-gradient(circle at 1px 1px, color-mix(in oklab, var(--fam) 34%, transparent) 1px, transparent 0)", backgroundSize: "18px 18px", WebkitMaskImage: "radial-gradient(90% 90% at 50% 0%, #000, transparent 75%)", maskImage: "radial-gradient(90% 90% at 50% 0%, #000, transparent 75%)" }}
-        />
-        <span
-          className="relative grid h-16 w-16 place-items-center rounded-2xl border shadow-[var(--shadow-sm)] transition-transform duration-300 group-hover:scale-105"
-          style={{ background: "color-mix(in oklab, var(--fam) 16%, var(--color-surface))", borderColor: "color-mix(in oklab, var(--fam) 40%, transparent)", color: "var(--fam)" }}
-        >
-          <svg width="30" height="30" viewBox="0 0 24 24" fill="none">
-            <path d={f.icon} stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
+        <span aria-hidden className="grid h-[11px] w-[11px] shrink-0 place-items-center rounded-[4px] text-[8px]" style={{ background: "var(--fam)", color: "var(--color-bg)" }}>
+          {n}
         </span>
-      </div>
-      <div className="flex flex-1 flex-col gap-2 p-6">
-        <div className="flex items-center gap-2.5">
-          <h3 className="text-[19px] font-semibold tracking-tight text-[var(--color-fg)]">{f.name}</h3>
-          <span
-            className="ml-auto rounded-full px-2.5 py-0.5 text-[12px] font-semibold tabular-nums"
-            style={{ background: "color-mix(in oklab, var(--fam) 16%, transparent)", color: "var(--fam)" }}
-          >
-            {n}
-          </span>
-        </div>
-        <p className="text-[14px] leading-relaxed text-[var(--color-muted)]">{f.value}</p>
-        <span className="mt-auto inline-flex items-center gap-1 pt-2 text-[13.5px] font-semibold" style={{ color: "var(--fam)" }}>
-          Explore {f.name} →
-        </span>
-      </div>
-    </Link>
+        <span className="truncate">{label}</span>
+      </span>
+      {children}
+    </div>
   );
 }
 
-/* ---- Pack card (product offering, static composition) ---- */
+/* Per-pack window interior — the block's real workspace layout, abstracted. */
+function PackShotRegions({ slug }: { slug: string }) {
+  switch (slug) {
+    case "ai-interface":
+      return (
+        <>
+          <ShotRegion area="ra" n={1} label="Runs">
+            <MPill w="80%" h={10} on style={{ borderRadius: 6 }} />
+            <div className="mt-[6px]">
+              <Ln w="70%" dim /><Ln w="85%" dim /><Ln w="60%" dim /><Ln w="75%" dim />
+            </div>
+          </ShotRegion>
+          <ShotRegion area="rb" n={3} label="Answer" className="pack-type">
+            <Ln w="92%" /><Ln w="84%" /><Ln w="95%" /><Ln w="70%" /><Ln w="40%" fam />
+          </ShotRegion>
+          <ShotRegion area="rc" n={4} label="Sources">
+            <MPill w="100%" h={16} style={{ borderRadius: 5 }} />
+            <MPill w="100%" h={16} style={{ borderRadius: 5, marginTop: 5 }} />
+            <MPill w="100%" h={16} on style={{ borderRadius: 5, marginTop: 5 }} />
+          </ShotRegion>
+          <ShotRegion area="rd" n={2} label="Tools">
+            <div className="flex flex-wrap gap-1">
+              <MPill w={56} on /><MPill w={44} /><MPill w={62} />
+            </div>
+          </ShotRegion>
+        </>
+      );
+    case "developer-tools":
+      return (
+        <>
+          <ShotRegion area="ra" n={1} label="Environments">
+            <div className="absolute right-[9px] top-[5px] flex gap-1">
+              <MPill w={52} /><MPill w={64} on /><MPill w={46} />
+            </div>
+          </ShotRegion>
+          <ShotRegion area="rb" n={2} label="Pipeline">
+            <div className="mt-[3px] flex items-center gap-1">
+              <MPill w="15%" h={14} on style={{ borderRadius: 5 }} />
+              <MPill w="15%" h={14} on style={{ borderRadius: 5 }} />
+              <MPill w="15%" h={14} on className="pack-blink" style={{ borderRadius: 5 }} />
+              <MPill w="15%" h={14} style={{ borderRadius: 5 }} />
+              <MPill w="15%" h={14} style={{ borderRadius: 5 }} />
+            </div>
+          </ShotRegion>
+          <ShotRegion area="rc" n={3} label="Live logs" className="pack-logs">
+            <Ln w="90%" dim /><Ln w="74%" dim /><Ln w="86%" dim /><Ln w="64%" fam />
+          </ShotRegion>
+          <ShotRegion area="rd" n={4} label="Inspector">
+            <div className="mb-[5px] flex gap-1">
+              <MPill w={38} h={11} on /><MPill w={30} h={11} />
+            </div>
+            <Ln w="88%" dim /><Ln w="66%" dim />
+          </ShotRegion>
+        </>
+      );
+    case "collaboration":
+      return (
+        <>
+          <ShotRegion area="ra" n={1} label="Presence">
+            <div className="absolute right-[9px] top-[5px] flex gap-1">
+              <MPill w={14} h={14} on round />
+              <MPill w={14} h={14} on round style={{ opacity: 0.7 }} />
+              <MPill w={14} h={14} round />
+              <MPill w={28} h={14} />
+            </div>
+          </ShotRegion>
+          <ShotRegion area="rc" n={3} label="Comments">
+            <Ln w="85%" /><Ln w="65%" dim /><Ln w="78%" dim ml="14px" /><Ln w="52%" fam ml="14px" />
+          </ShotRegion>
+          <ShotRegion area="rb" n={2} label="Approvals">
+            <MPill w="100%" h={18} on style={{ borderRadius: 6 }} />
+            <MPill w="100%" h={18} style={{ borderRadius: 6, marginTop: 5 }} />
+            <MPill w="100%" h={18} style={{ borderRadius: 6, marginTop: 5 }} />
+          </ShotRegion>
+          <ShotRegion area="rd" n={4} label="Activity" className="pack-rows">
+            <Ln w="80%" dim />
+          </ShotRegion>
+        </>
+      );
+    default: // data-motion
+      return (
+        <>
+          <ShotRegion area="ra" n={1} label="KPIs">
+            <div className="flex gap-[5px]">
+              {["24.8k", "99.98%", "312ms", "$41.2k"].map((v) => (
+                <span key={v} className="flex-1 rounded-[6px] px-[6px] py-[5px]" style={{ background: "color-mix(in oklab, var(--color-fg) 6%, transparent)" }}>
+                  <span className="block text-[10px] font-bold tabular-nums text-[var(--color-fg-secondary)]">{v}</span>
+                  <span className="mt-[3px] block h-[3.5px] w-[70%] rounded-[3px]" style={{ background: "color-mix(in oklab, var(--color-fg) 10%, transparent)" }} />
+                </span>
+              ))}
+            </div>
+          </ShotRegion>
+          <ShotRegion area="rb" n={2} label="Refresh">
+            <MPill w={52} h={12} on className="pack-blink" style={{ position: "absolute", right: 9, top: 6 }} />
+          </ShotRegion>
+          <ShotRegion area="rc" n={3} label="Filters">
+            <div className="absolute right-[9px] top-[6px] flex gap-1">
+              <MPill w={40} on /><MPill w={34} />
+            </div>
+          </ShotRegion>
+          <ShotRegion area="rd" n={4} label="Streaming rows" className="pack-rows">
+            <Ln w="96%" /><Ln w="96%" dim /><Ln w="96%" dim /><Ln w="80%" dim />
+          </ShotRegion>
+        </>
+      );
+  }
+}
+
 function PackCard({ p }: { p: Pack }) {
   const comps = p.components.map((s) => bySlug.get(s)).filter(Boolean) as CatalogItem[];
+  const art = PACK_ART[p.slug] ?? PACK_ART["ai-interface"];
   return (
-    <Link
-      href={`/packs/${p.slug}`}
-      className="group relative flex flex-col overflow-hidden rounded-3xl border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-sm)] transition-all hover:-translate-y-0.5 hover:border-[color-mix(in_oklab,var(--color-accent)_45%,var(--color-border))] hover:shadow-[var(--shadow-md)]"
+    <div
+      className="group relative flex flex-col overflow-hidden rounded-3xl border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-sm)] transition-all duration-300 hover:-translate-y-1 hover:border-[color-mix(in_oklab,var(--fam)_46%,var(--color-border))] hover:shadow-[var(--shadow-md)]"
+      style={{ ["--fam" as string]: art.c }}
     >
-      {/* Static composition: the block, evoked as a layered stack of its parts. */}
-      <div className="relative overflow-hidden border-b border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-6">
-        <div
+      {/* family hairline across the top */}
+      <span
+        aria-hidden
+        className="absolute inset-x-0 top-0 z-10 h-[2px]"
+        style={{ background: "linear-gradient(to right, transparent, color-mix(in oklab, var(--fam) 72%, transparent), transparent)" }}
+      />
+
+      <div className="flex items-center gap-3.5 px-[26px] pt-6">
+        <span
           aria-hidden
-          className="pointer-events-none absolute inset-0 opacity-70"
-          style={{ background: "radial-gradient(120% 120% at 15% -20%, color-mix(in oklab, var(--color-accent) 12%, transparent), transparent 60%)" }}
+          className="grid h-[46px] w-[46px] shrink-0 place-items-center rounded-[14px]"
+          style={{
+            color: "var(--fam)",
+            background: "color-mix(in oklab, var(--fam) 14%, var(--color-surface))",
+            border: "1px solid color-mix(in oklab, var(--fam) 35%, transparent)",
+          }}
+        >
+          <svg width="23" height="23" viewBox="0 0 24 24" fill="none">
+            <path d={art.icon} stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </span>
+        <span className="min-w-0">
+          <h3 className="text-[20px] font-semibold tracking-[-0.016em] text-[var(--color-fg)]">
+            <Link href={`/packs/${p.slug}`} className="outline-none hover:text-[var(--color-accent-text)]">
+              {p.name}
+            </Link>
+          </h3>
+          <span className="block truncate text-[12.5px] text-[var(--color-subtle)]">Installs the {p.blockName} block</span>
+        </span>
+        <span
+          className="ml-auto shrink-0 rounded-full px-3 py-[4.5px] text-[11.5px] font-semibold"
+          style={{ color: "var(--fam)", background: "color-mix(in oklab, var(--fam) 12%, transparent)" }}
+        >
+          {comps.length} components
+        </span>
+      </div>
+
+      <p className="mt-3 px-[26px] text-[14px] leading-relaxed text-[var(--color-muted)]">{p.tagline}</p>
+
+      {/* the block, as a product shot */}
+      <div className="relative mx-[26px] mt-[18px]" aria-hidden>
+        <span
+          className="pointer-events-none absolute -inset-3.5 rounded-[20px]"
+          style={{ background: "radial-gradient(70% 60% at 50% 20%, color-mix(in oklab, var(--fam) 13%, transparent), transparent 72%)" }}
         />
-        <div className="relative">
-          <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1 text-[11.5px] font-medium text-[var(--color-muted)]">
-            <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-accent)]" /> Installs 1 block · {comps.length} components
-          </span>
-          <div className="mt-4 space-y-2">
-            {comps.map((c, i) => (
-              <div
-                key={c.id}
-                className="flex items-center gap-3 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] px-3.5 py-2.5 shadow-[var(--shadow-sm)]"
-                style={{ marginLeft: `${i * 10}px`, width: `calc(100% - ${i * 10}px)` }}
-              >
-                <span className="grid h-6 w-6 shrink-0 place-items-center rounded-md bg-[color-mix(in_oklab,var(--color-accent)_14%,transparent)] text-[11px] font-semibold text-[var(--color-accent-text)]" aria-hidden>
-                  {i + 1}
-                </span>
-                <span className="truncate text-[13px] font-medium text-[var(--color-fg)]">{c.name}</span>
-                {c.featured ? (
-                  <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-label="Featured" className="ml-auto shrink-0 text-[var(--color-accent-text)]">
-                    <path d="M12 2l2.9 6.26L22 9.27l-5 4.87L18.18 22 12 18.56 5.82 22 7 14.14l-5-4.87 7.1-1.01L12 2z" />
-                  </svg>
-                ) : null}
-              </div>
-            ))}
+        <div className="relative overflow-hidden rounded-[15px] border border-[var(--color-border-strong)] bg-[var(--color-bg-elevated)] shadow-[var(--shadow-lg)]">
+          <div className="flex h-[30px] items-center border-b border-[var(--color-border)] bg-[color-mix(in_oklab,var(--color-surface)_65%,var(--color-bg-elevated))] px-3">
+            <span className="flex gap-[6px]">
+              <i className="h-2 w-2 rounded-full bg-[var(--color-surface-strong)]" />
+              <i className="h-2 w-2 rounded-full bg-[var(--color-surface-strong)]" />
+              <i className="h-2 w-2 rounded-full bg-[var(--color-surface-strong)]" />
+            </span>
+            <span className="mx-auto rounded-[6px] border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-[2px] font-mono text-[9.5px] text-[var(--color-subtle)]">
+              {art.addr}
+            </span>
+          </div>
+          <div className="grid h-[208px] gap-[7px] p-[9px]" style={art.grid}>
+            <PackShotRegions slug={p.slug} />
           </div>
         </div>
       </div>
 
-      <div className="flex flex-1 flex-col p-6">
-        <p className="text-[12px] font-semibold uppercase tracking-wide text-[var(--color-accent-text)]">Complete workflow</p>
-        <h3 className="mt-1.5 text-[20px] font-semibold tracking-tight text-[var(--color-fg)]">{p.name}</h3>
-        <p className="mt-2 text-[14px] leading-relaxed text-[var(--color-muted)]">{p.tagline}</p>
-        <div className="mt-5 flex items-center justify-between gap-3 border-t border-[var(--color-border)] pt-4">
-          <span className="text-[13px] font-medium text-[var(--color-muted)]">
-            <span className="text-[var(--color-fg)]">{comps.length} components</span> · {p.blockName}
+      {/* legend — numbers → real component names */}
+      <div className="mt-3.5 flex flex-wrap gap-1.5 px-[26px]">
+        {comps.map((c, i) => (
+          <span
+            key={c.id}
+            className="inline-flex items-center gap-[7px] rounded-full border border-[var(--color-border)] bg-[var(--color-bg-elevated)] py-[5px] pl-[6px] pr-3 text-[12px] font-semibold text-[var(--color-fg-secondary)]"
+          >
+            <span
+              aria-hidden
+              className="grid h-[17px] w-[17px] place-items-center rounded-full text-[9.5px] font-bold"
+              style={{ background: "color-mix(in oklab, var(--fam) 80%, var(--color-fg))", color: "var(--color-bg)" }}
+            >
+              {i + 1}
+            </span>
+            {c.name}
+            {c.featured ? (
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" aria-label="Featured" style={{ color: "var(--fam)" }}>
+                <path d="M12 2l2.9 6.26L22 9.27l-5 4.87L18.18 22 12 18.56 5.82 22 7 14.14l-5-4.87 7.1-1.01L12 2z" />
+              </svg>
+            ) : null}
           </span>
-          <span className="inline-flex items-center gap-1 rounded-lg bg-[var(--color-accent)] px-3.5 py-2 text-[13px] font-semibold text-[var(--color-accent-fg)] transition-colors group-hover:bg-[var(--color-accent-hover)]">
-            View pack →
-          </span>
-        </div>
+        ))}
       </div>
-    </Link>
+
+      <div className="mt-5 flex items-center gap-3 border-t border-[var(--color-border)] px-[18px] pb-[18px] pt-[15px]">
+        <InstallChip
+          command={installCommand(p.packRegistryItem)}
+          display={`${product.registryBaseUrl.replace(/^https?:\/\//, "")}/${p.packRegistryItem}`}
+        />
+        <Link
+          href={`/packs/${p.slug}`}
+          className="inline-flex h-10 shrink-0 items-center rounded-[11px] bg-[var(--color-accent)] px-[18px] text-[13.5px] font-semibold text-[var(--color-accent-fg)] shadow-[var(--shadow-sm)] transition-colors hover:bg-[var(--color-accent-hover)]"
+        >
+          View pack
+        </Link>
+      </div>
+    </div>
   );
 }
 
@@ -287,20 +672,8 @@ const HERO_STREAM_SEGMENTS: ResponseSegment[] = [
 ];
 
 export default function HomePage() {
-  const featured = featuredItems();
-  const featuredSpans = packSpans(featured);
-
   const componentTotal = componentItems().length;
   const blockTotal = blockItems().length;
-
-  // Product environments showcase — a controlled selection (not all ten): one
-  // lead animated background, one hero block, and two more backgrounds. Each
-  // renders through LazyPreview (mounts on scroll) + the components' own
-  // offscreen pause + reduced-motion, so nothing autoplays off-screen.
-  const productEnvLead = bySlug.get("runtime-signal-map");
-  const productEnvCards = ["agent-operations-hero", "workflow-topology-field", "queue-pulse-lanes"]
-    .map((s) => bySlug.get(s))
-    .filter(Boolean) as CatalogItem[];
 
   const catalogList = componentItems();
   const catalogJsonLd = {
@@ -587,119 +960,88 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* ===== 3 · Featured components — editorial showcase on the page base ===== */}
-      <section className="mx-auto max-w-[1440px] px-4 py-14 sm:px-6 lg:px-8">
-        <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
-          <div className="max-w-xl">
-            <p className="text-[13px] font-semibold uppercase tracking-wide text-[var(--color-accent-text)]">The catalog</p>
-            <h2 className="mt-2 text-[clamp(1.8rem,3.4vw,2.7rem)] font-semibold tracking-tight text-[var(--color-fg)]">Featured components</h2>
-            <p className="mt-2.5 text-[15px] leading-relaxed text-[var(--color-muted)]">Six of the catalog’s strongest - each preview is the real component in one representative state.</p>
-          </div>
-          <Link href="/components" className="shrink-0 text-[14px] font-semibold text-[var(--color-accent-text)] hover:underline">
-            All components →
-          </Link>
-        </div>
-        <div className="grid grid-cols-12 items-start gap-5">
-          {featured.map((item) => {
-            const span = featuredSpans.get(item.id) ?? 6;
-            return (
-              <div key={item.id} className={SPAN_CLASS[span]}>
-                <FeaturedCard item={item} wide={span === 12} />
-              </div>
-            );
-          })}
-        </div>
-      </section>
+      {/* ===== 3 · The catalog, one unified animated grid (docs/61 §catalog).
+              Formerly two sections ("Featured components" + "Backgrounds that
+              carry product state"); merged so the page tells the catalog story
+              once. Bento order: interactive lead → workflow surfaces →
+              environments → the text finale. Cards rise in on scroll (Reveal),
+              each scene carries one ambient loop, and hover adds lift + sheen. ===== */}
+      <section className="relative isolate overflow-clip py-16 lg:py-[96px]">
+        <SectionAtmo dots counter />
+        <div className="mx-auto max-w-[1440px] px-4 sm:px-6 lg:px-8">
+          <SectionHead
+            eyebrow="The catalog"
+            title="Every surface your product ships"
+            desc={`Workflow surfaces, animated environments, and text — ${categories.length} categories, each shown in one live state. Open a category to preview and install its ${componentTotal} components.`}
+            href="/components"
+            cta={`All ${categories.length} categories`}
+          />
 
-      {/* ===== 3.5 · Product environments — animated backgrounds driven by app
-              state + one editable workflow hero. A controlled selection (four of
-              ten), each lazy-mounted and offscreen-paused so nothing autoplays
-              off-screen. ===== */}
-      <section className="mx-auto max-w-[1440px] px-4 py-14 sm:px-6 lg:px-8">
-        <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
-          <div className="max-w-xl">
-            <p className="text-[13px] font-semibold uppercase tracking-wide text-[var(--color-accent-text)]">Product environments</p>
-            <h2 className="mt-2 text-[clamp(1.8rem,3.4vw,2.7rem)] font-semibold tracking-tight text-[var(--color-fg)]">Backgrounds that carry product state</h2>
-            <p className="mt-2.5 max-w-xl text-[15px] leading-relaxed text-[var(--color-muted)]">
-              Animated backgrounds driven by your application state, and editable hero blocks that demonstrate a real
-              workflow - foreground-safe, reduced-motion-safe, and never just decoration.
-            </p>
-          </div>
-          <Link href="/components?category=product-backgrounds" className="shrink-0 text-[14px] font-semibold text-[var(--color-accent-text)] hover:underline">
-            All environments →
-          </Link>
-        </div>
-        {productEnvLead ? (
-          <div className="group relative mb-5 overflow-hidden rounded-3xl border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-sm)] transition-all duration-300 hover:border-[color-mix(in_oklab,var(--color-accent)_35%,var(--color-border))] hover:shadow-[var(--shadow-md)]">
-            <LazyPreview label={`${productEnvLead.name} preview`} minHeightClass="min-h-[420px]">
-              <div className="relative w-full bg-[var(--color-bg)]">
-                <RuntimeSignalMapHeroPreview />
-              </div>
-            </LazyPreview>
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-[var(--color-border)] px-6 py-4">
-              <h3 className="text-[17px] font-semibold tracking-tight text-[var(--color-fg)]">
-                <Link href={productEnvLead.documentationPath} className="outline-none after:absolute after:inset-0 hover:text-[var(--color-accent-text)]">
-                  {productEnvLead.name}
-                </Link>
-              </h3>
-              <FeaturedPill featured={productEnvLead.featured} />
-              <span className="ml-auto inline-flex items-center gap-1 text-[13.5px] font-medium text-[var(--color-accent-text)]">
-                Open component →
-              </span>
+          <div className="grid grid-cols-12 items-stretch gap-5">
+            {/* Lead card — the most kinetic surface in the catalog. */}
+            <div className="col-span-12">
+              <Reveal>
+                <MediaGalleryHero count={categoryCount("media")} href={categoryHref("media")} />
+              </Reveal>
             </div>
-          </div>
-        ) : null}
-        <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-          {productEnvCards.map((item) => (
-            <FeaturedCard key={item.id} item={item} />
-          ))}
-        </div>
-      </section>
 
-      {/* ===== 4 · Workflow categories — vibrant but controlled, warm sand band ===== */}
-      <section className="relative">
-        <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 border-y border-[var(--color-border)] bg-[var(--color-bg-secondary)]" />
-        <div className="mx-auto max-w-[1440px] px-4 py-16 sm:px-6 lg:px-8">
-          <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
-            <div className="max-w-xl">
-              <p className="text-[13px] font-semibold uppercase tracking-wide text-[var(--color-accent-text)]">By workflow</p>
-              <h2 className="mt-2 text-[clamp(1.8rem,3.4vw,2.7rem)] font-semibold tracking-tight text-[var(--color-fg)]">Built for real workflows</h2>
-              <p className="mt-2.5 text-[15px] leading-relaxed text-[var(--color-muted)]">Eight product families - each with its own accent - pick a surface, preview it live, install what you need.</p>
-            </div>
-            <Link href="/components" className="shrink-0 text-[14px] font-semibold text-[var(--color-accent-text)] hover:underline">
-              All categories →
-            </Link>
-          </div>
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            {FAMILIES.map((f) => (
-              <CategoryTile key={f.cat} f={f} />
+            {CATALOG_CARDS.map((c, i) => (
+              <div key={c.cat} className={SPAN_CLASS[c.span ?? 4]}>
+                {/* stagger resets per row so a wide card never delays the next row */}
+                <Reveal delay={(i % 3) * 70} className="h-full">
+                  <CategoryCard {...c} />
+                </Reveal>
+              </div>
             ))}
           </div>
         </div>
       </section>
 
-      {/* ===== 5 · Complete packs — productized, azure-lit elevated band ===== */}
+      {/* ===== 4 · Category index (docs/61). The showcase above presents six
+              categories as full cards; repeating that card design here made the
+              same names appear twice, so this is now the complete, compact
+              browse surface — every category, one row of chips. ===== */}
       <section className="relative">
-        <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 bg-[var(--color-bg-elevated)]" />
-        <div aria-hidden className="pointer-events-none absolute inset-0 -z-10" style={{ background: "radial-gradient(55% 55% at 88% -5%, var(--color-spotlight), transparent 62%)" }} />
-        {/* subtle azure edge-light across the top of the band */}
-        <div aria-hidden className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-px" style={{ background: "linear-gradient(to right, transparent, color-mix(in oklab, var(--color-accent) 40%, transparent), transparent)" }} />
-        <div className="mx-auto max-w-[1440px] px-4 py-16 sm:px-6 lg:px-8">
-          <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
-            <div className="max-w-xl">
-              {/* the one small Coral commercial highlight in this section */}
-              <p className="inline-flex items-center gap-2 text-[13px] font-semibold uppercase tracking-wide text-[var(--color-accent-text)]">
-                <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-signature)]" aria-hidden />
-                Ship faster
+        <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 border-y border-[var(--color-border)] bg-[var(--color-bg-secondary)]" />
+        <div className="mx-auto max-w-[1440px] px-4 py-14 sm:px-6 lg:px-8">
+          <div className="mb-7 flex flex-wrap items-end justify-between gap-5">
+            <div className="max-w-[640px]">
+              <p className="inline-flex items-center gap-2.5 text-[12.5px] font-semibold uppercase tracking-[0.12em] text-[var(--color-accent-text)]">
+                <span aria-hidden className="h-[1.5px] w-[22px] rounded-full bg-[var(--color-accent)]" />
+                By workflow
               </p>
-              <h2 className="mt-2 text-[clamp(1.8rem,3.4vw,2.7rem)] font-semibold tracking-tight text-[var(--color-fg)]">Complete workflow packs</h2>
-              <p className="mt-2.5 text-[15px] leading-relaxed text-[var(--color-muted)]">Finished product outcomes - four components composed into one installable, app-controlled block.</p>
+              <h2 className="mt-3 text-[clamp(1.5rem,2.6vw,2.05rem)] font-semibold leading-[1.1] tracking-[-0.02em] text-[var(--color-fg)]">
+                Built for real workflows
+              </h2>
+              <p className="mt-3 text-[15px] leading-relaxed text-[var(--color-muted)]">
+                Every category in the catalog — pick a surface, preview it live, install what you need.
+              </p>
             </div>
-            <Link href="/packs" className="shrink-0 text-[14px] font-semibold text-[var(--color-accent-text)] hover:underline">
-              All packs →
-            </Link>
           </div>
-          <div className="grid grid-cols-1 items-stretch gap-5 md:grid-cols-2">
+          <div className="grid grid-cols-2 gap-3.5 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+            {categories.map((c, i) => (
+              <Reveal key={c.id} delay={(i % 5) * 55} className="h-full">
+                <CategoryIndexCard cat={c} />
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ===== 5 · Complete packs (docs/61) — product shots of the composed
+              blocks, coral "ship faster" eyebrow, azure-lit band ===== */}
+      <section className="relative isolate overflow-clip py-16 lg:py-[88px]">
+        <SectionAtmo dots counter />
+        <div className="mx-auto max-w-[1440px] px-4 sm:px-6 lg:px-8">
+          <SectionHead
+            eyebrow="Ship faster"
+            signature
+            title="Complete workflow packs"
+            desc="Finished product outcomes — four components composed into one installable, app-controlled block. One command, editable source."
+            href="/packs"
+            cta="All packs"
+          />
+          <div className="grid grid-cols-1 items-stretch gap-5 lg:grid-cols-2">
             {packs.map((p) => (
               <PackCard key={p.slug} p={p} />
             ))}

--- a/apps/docs/lib/catalog.ts
+++ b/apps/docs/lib/catalog.ts
@@ -1758,8 +1758,9 @@ export const catalog: CatalogItem[] = [
     registryItem: "kinetic-emphasis",
     documentationPath: "/components/kinetic-emphasis",
     dateAdded: ADDED,
-    // Independently Strongly Sellable (2026-07-14 premium re-review) — homepage-eligible.
-    featured: true,
+    // 2026-08-01 homepage refresh: Decrypt Text now carries the Text & creative
+    // featured slot; Kinetic Emphasis remains catalog-listed but not featured.
+    featured: false,
     supportsDarkMode: true,
     supportsReducedMotion: true,
     requiresClient: true,
@@ -2033,7 +2034,8 @@ export const catalog: CatalogItem[] = [
     registryItem: "decrypt-text",
     documentationPath: "/components/decrypt-text",
     dateAdded: "2026-07-28",
-    featured: false,
+    // 2026-08-01 homepage refresh: featured — full-width Text & creative finale.
+    featured: true,
     supportsDarkMode: true,
     supportsReducedMotion: true,
     requiresClient: true,


### PR DESCRIPTION
Homepage
- Merge "Featured components" and "Backgrounds that carry product state" into one animated section, "Every surface your product ships": a 9-card bento (lead 12 / 8+4 / 4+4+4 / 6+6 / 12) covering every catalog family.
- Sell CATEGORIES, not single components. Each card carries a simplified scene standing for that category's work, its live component count, and links to the filtered catalog; full live previews stay on the category/component pages.
- Lead card is the real Velocity Marquee (Media & galleries) — two counter-rotating rails over in-canvas generated art, so no image assets ship.
- Ambient backgrounds renders the real Copperplate Hatch, thinned for card scale.
- Text animations renders the real Decrypt Text; swap the `featured` flag from kinetic-emphasis to decrypt-text so the flag and the layout agree.
- "Built for real workflows" becomes the complete browse index: all 20 categories as denser icon-led cards, so it never duplicates the showcase. One CATEGORY_META map now owns every category's accent + glyph.

Motion
- New Reveal primitive: staggered scroll entrance. SSR renders NO data-reveal attribute so markup ships visible — the hidden state is applied client-side and only below the fold, where the flip cannot be seen. Pairs IntersectionObserver with a scroll/resize fallback for renderers that report the document hidden.
- Per-scene ambient loops, hover lift/sheen/accent rails; all collapse under prefers-reduced-motion.

Navigation
- Extract the component-docs rail's visual language into sidebar-nav.tsx and the mobile sheet into nav-sheet.tsx; /components now uses both, so the two rails are the same code rather than lookalikes. Categories there expand to their components, and the mobile filter panel becomes the same focus-trapped, scroll-locked slide-in sheet.

Fixes
- Pack hero rendered two identical "Explore components" buttons: packPrimaryCta degrades to the explore CTA in the free/open catalog, colliding with the hardcoded companion. Pair it with an install jump instead, and anchor the Installation section.

## What does this PR do?

Briefly describe the change and the motivation.

## Related issues

Closes #

## Checklist

- [ ] Focused change (one component or concern)
- [ ] Accessible — keyboard, focus, screen-reader semantics, contrast (WCAG 2.2 AA)
- [ ] Respects `prefers-reduced-motion`; continuous animation pauses offscreen
- [ ] RSC-safe (`"use client"` only where needed)
- [ ] Uses semantic tokens (no unnecessary hardcoded values)
- [ ] Tests added/updated (unit / SSR / reduced-motion / axe)
- [ ] Preview + docs updated; registry rebuilt if a component changed
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm docs:check` pass
