### PR TITLE
chore: implement OpenSSF security posture

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Satisfies the OpenSSF Scorecard "Dependency-Update-Tool" check, and — more usefully —
+# keeps the two ecosystems that can actually compromise a release current: the npm tree
+# that gets built into published packages, and the GitHub Actions that do the building.
+#
+# Actions are pinned to commit SHAs in the workflows (Scorecard "Pinned-Dependencies").
+# A SHA pin is invisible to a human reviewer, so Dependabot's github-actions updater is
+# what keeps those pins from silently rotting into unpatched versions.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # One PR per ecosystem-wide bump keeps review load proportional to risk: dev
+      # tooling churns constantly and is not shipped to users.
+      dev-dependencies:
+        dependency-type: development
+        update-types: [minor, patch]
+    labels: [dependencies]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: [dependencies, ci]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ on:
   pull_request:
     paths-ignore: *docs-only
 
+# Least privilege for GITHUB_TOKEN: nothing here writes to the repository, so a
+# compromised dependency in a build step gets a read-only token (OpenSSF Scorecard
+# "Token-Permissions"). A job that needs more must ask for it explicitly.
+permissions:
+  contents: read
+
 # Auto-cancel a superseded run when new commits land on the same branch/PR, so rapid
 # pushes don't queue up full builds behind each other.
 concurrency:
@@ -28,9 +34,9 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           # Single source of truth for the supported floor (README + CONTRIBUTING
           # + package.json engines all state 22.13); CI proves that floor works.
@@ -64,9 +70,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: verify
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           # Single source of truth for the supported floor (README + CONTRIBUTING
           # + package.json engines all state 22.13); CI proves that floor works.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+# CodeQL — static analysis, and the concrete thing that satisfies the OpenSSF Scorecard
+# "SAST" check. Free for public repositories.
+#
+# Scope is the JS/TS in this repository: component source, the docs app, and the build
+# and check scripts. `build-mode: none` is correct here — CodeQL analyses TypeScript
+# without needing the turbo/tsdown build to run, so this stays independent of CI.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so a newly published query rule finds an old vulnerability even when
+    # nothing has been pushed.
+    - cron: "41 5 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze JS/TS
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # write findings to the code-scanning tab
+      packages: read
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          # security-extended adds the lower-severity queries. This repo ships source
+          # that other people paste into their apps, so a "maybe" finding in a component
+          # is worth a human look.
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,61 @@
+# OpenSSF Scorecard — automated audit of this repository's security posture.
+#
+# Scorecard grades ~18 checks (branch protection, pinned dependencies, SAST, token
+# permissions, security policy, signed releases...) and writes the result to GitHub's
+# code-scanning tab. `publish_results: true` also pushes the score to the public OpenSSF
+# API, which is what makes the README badge resolve and what lets downstream consumers
+# see the score without asking.
+#
+# NOTE: Scorecard is a SECURITY-PRACTICE score (0-10). It is not the criticality score
+# (0-1), which measures how much the ecosystem depends on this repo and cannot be moved
+# by configuration. See scripts/openssf-criticality.mjs and docs/17.
+name: Scorecard
+
+on:
+  branch_protection_rule: # re-grade when branch protection changes
+  schedule:
+    - cron: "27 4 * * 1" # Mondays; off the hour to avoid the scheduler stampede
+  push:
+    branches: [main]
+
+# Least privilege at the workflow level; the one job that needs more declares it.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload the SARIF result to code scanning
+      id-token: write # OIDC token used to publish results to the OpenSSF API
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishing is what produces the public score + badge. It publishes only the
+          # check results for this public repo — no source, no secrets.
+          publish_results: true
+
+      # Kept for 5 days so a regression can be diffed against the previous week without
+      # waiting for the next scheduled run.
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: results.sarif

--- a/docs/05-dependency-decisions.md
+++ b/docs/05-dependency-decisions.md
@@ -45,7 +45,7 @@ Run through [`dependency-review`](../.claude/skills/component-review/SKILL.md); 
 | `axe-core` / `@axe-core/playwright` | A11y assertions | **devDep** | MPL-2.0 | current | — | — | pa11y | ✅ (MPL fine as devDep) | 2026-07-14 |
 | `@changesets/cli` | Versioning/changelog | **devDep** | MIT | current | — | — | semantic-release | ✅ | 2026-07-14 |
 | `turbo` | Task orchestration/cache | **devDep** | MIT | current | — | — | Nx (heavier) | ✅ | 2026-07-14 |
-| `pnpm` | Package manager | tool | MIT | 11.x (11.13.0 present 🟢) | — | — | npm, yarn | ✅ 🟢 available | 2026-07-14 |
+| `pnpm` | Package manager | tool | MIT | 11.x (11.25.0 present 🟢) | — | — | npm, yarn | ✅ 🟢 available (11.12.0–11.13.0 are broken releases — `@pnpm/exe` shipped without a binary; do not pin them) | 2026-09-04 |
 | `size-limit` + preset | Bundle budgets in CI | **devDep** | MIT | current | — | — | bundlewatch | ✅ | 2026-07-14 |
 | `lucide-react` | Icons | **peer/optional** | ISC | current | tree-shakeable | ✅ | heroicons, tabler | ✅ (don't ship own icon pkg) | 2026-07-14 |
 | `eslint` + `@typescript-eslint` + boundary plugin | Lint/import boundaries | **devDep** | MIT | current | — | — | biome | ✅ | 2026-07-14 |

--- a/docs/17-security-and-supply-chain.md
+++ b/docs/17-security-and-supply-chain.md
@@ -1,7 +1,7 @@
 # 17 — Security, supply chain & code quality
 
-> **Type:** 🟢 Canonical for supply-chain, secrets, and code-quality standards · **Implementation status:** 🔵 Planned · **Last reviewed:** 2026-07-14
-> **Owns:** secret handling, publishing security, strict-TS policy, coding conventions.
+> **Type:** 🟢 Canonical for supply-chain, secrets, and code-quality standards · **Implementation status:** 🟡 Partial (OpenSSF posture shipped; release signing pending) · **Last reviewed:** 2026-09-04
+> **Owns:** secret handling, publishing security, OpenSSF posture, strict-TS policy, coding conventions.
 > **Related:** [`16-commercial-packaging.md`](16-commercial-packaging.md) · [`18-release-process.md`](18-release-process.md) · [`05-dependency-decisions.md`](05-dependency-decisions.md) · [`dependency-review` skill](../.claude/skills/component-review/SKILL.md)
 
 ## Security & supply chain
@@ -15,6 +15,101 @@
 - **Source maps** — no secrets in maps; decide public vs private maps per package.
 - **No customer-data collection.** **Telemetry off by default**, opt-in only, disclosed.
 - **Build reproducibility** — pinned toolchain; deterministic builds.
+
+## OpenSSF posture
+
+Two OpenSSF numbers get confused with each other constantly, and only one of them is
+something this repository can decide.
+
+| | **Scorecard** | **Criticality score** |
+|---|---|---|
+| Measures | how safely this repo is *run* | how much the ecosystem *depends* on it |
+| Range | 0–10 | 0–1 |
+| Moved by | configuration and process — this section | adoption, contributors, issue traffic, time |
+| Our control | direct | indirect and slow |
+
+The "critical infrastructure" bar people cite — **criticality ≥ 0.4** — is the second one.
+No file added to this repository moves it. It is a weighted mean of ten observed signals
+(age, recency, contributor count, contributor-org count, commit frequency, releases,
+issues opened/closed in 90 days, comment frequency, downstream mentions), each normalized
+against a threshold set by projects like Kubernetes and Linux. Writing more workflows
+scores exactly zero of it.
+
+### Measuring criticality
+
+[`scripts/openssf-criticality.mjs`](../scripts/openssf-criticality.mjs) reimplements
+upstream's algorithm (`config/scorer/original_pike.yml` plus `internal/scorer/algorithm`)
+against the GitHub API, so the number is measured rather than estimated:
+
+```bash
+pnpm openssf:criticality          # add GITHUB_TOKEN for the auth-only signals
+```
+
+It prints per-signal **headroom** — how much of the final score each signal is currently
+leaving on the table — which is the only useful way to read it. A signal that cannot be
+collected is dropped from the denominator, exactly as upstream does, so a partial run
+reports an *optimistic* score; the script says which ones were dropped.
+
+Baseline on 2026-09-04, nine of ten signals collected: **0.215**.
+
+| signal | raw | normalized |
+|---|---|---|
+| created_since | 1.7 months | 0.21 |
+| updated_since | 0.8 months | 1.00 |
+| contributor_count | 1 | 0.08 |
+| org_count | 0 | 0.00 |
+| commit_frequency | 0.35 / week | 0.04 |
+| recent_release_count | 2 | 0.33 |
+| updated_issues_count | 0 | 0.00 |
+| closed_issues_count | 0 | 0.00 |
+| github_mention_count | 20 | 0.23 |
+
+Recency is already maxed; everything else is adoption. The binding constraints are
+contributor count, contributor orgs, issue traffic, and downstream mentions — none of
+which CI can manufacture. Repo age accrues on its own schedule. This is the expected shape
+for a young single-maintainer project and is not a defect to be fixed in a workflow.
+
+(A run that drops a signal reports higher — 0.235 when commit-frequency stats were
+unavailable — because the dropped weight leaves the denominator. Compare runs only when
+the same signals were collected.)
+
+### Scorecard — what is implemented
+
+| Check | Status | Where |
+|---|---|---|
+| Security-Policy | ✅ | [`SECURITY.md`](../SECURITY.md) |
+| License | ✅ | [`LICENSE`](../LICENSE) |
+| CI-Tests | ✅ | [`ci.yml`](../.github/workflows/ci.yml) |
+| SAST | ✅ CodeQL, `security-extended` | [`codeql.yml`](../.github/workflows/codeql.yml) |
+| Dependency-Update-Tool | ✅ npm + github-actions | [`dependabot.yml`](../.github/dependabot.yml) |
+| Pinned-Dependencies | ✅ actions by SHA; committed lockfile | [`ci.yml`](../.github/workflows/ci.yml) |
+| Token-Permissions | ✅ explicit `permissions:` per workflow | all workflows |
+| Dangerous-Workflow | ✅ no `pull_request_target`, no untrusted checkout | — |
+| Scorecard itself | ✅ weekly, results published | [`scorecard.yml`](../.github/workflows/scorecard.yml) |
+
+The README badge is deliberately **not** added yet. `publish_results` has to run on the
+default branch once before `img.shields.io/ossf-scorecard/...` resolves to anything, and
+the first score will be held down by the four checks below. Read the real number at
+<https://scorecard.dev/viewer/?uri=github.com/RMahammad/motiq>, then decide whether it
+belongs above the fold.
+
+### Scorecard — what is not, and why
+
+- **Branch-Protection** — a repository *setting*, not a file. Requires, on `main`: require
+  a PR before merging, require status checks (`verify`, `fixtures`), and dismiss stale
+  approvals. Must be set by the owner in repo settings.
+- **Signed-Releases / Packaging** — needs a publish workflow with npm provenance
+  (`npm publish --provenance`, `id-token: write`). Deliberately not written yet: the
+  changeset config still declares `"access": "restricted"`, so the publishing target is an
+  open decision ([`18`](18-release-process.md)). Provenance is the requirement recorded above.
+- **Code-Review** — needs a second reviewer on merged PRs. Structurally unavailable to a
+  single maintainer; will improve only with contributors.
+- **Contributors** — needs contributors from ≥ 2 organizations. Same constraint.
+- **Fuzzing** — not pursued. This is a presentational component library with no parser and
+  no untrusted input surface; a fuzzer here would buy points, not safety.
+- **CII-Best-Practices** — the OpenSSF Best Practices badge is a self-certification
+  questionnaire at <https://www.bestpractices.dev>. Worth filling in; most criteria are
+  already met by the rows above.
 
 ## Code-quality standards
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.13.0",
+  "packageManager": "pnpm@11.25.0",
   "engines": {
     "node": ">=22.13"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "check:exposure": "node scripts/audit-pro-exposure.mjs",
     "test:staging": "node scripts/staging-lifecycle-test.mjs",
     "check:live-drivers": "node scripts/check-live-drivers.mjs",
-    "check:guide-examples": "node scripts/sync-guide-examples.mjs --check"
+    "check:guide-examples": "node scripts/sync-guide-examples.mjs --check",
+    "openssf:criticality": "node scripts/openssf-criticality.mjs"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.0",

--- a/scripts/openssf-criticality.mjs
+++ b/scripts/openssf-criticality.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+/**
+ * Measures this repository's OpenSSF criticality score.
+ *
+ * The score is NOT a property you can add to a repo — it is a computed function of ten
+ * observed signals (age, activity, contributors, issue traffic, downstream mentions).
+ * Adding files never moves it; adoption and sustained activity do. This script exists so
+ * the number is measured rather than guessed, and so it is obvious WHICH signal is the
+ * binding constraint at any moment.
+ *
+ * Algorithm mirrors ossf/criticality_score exactly (config/scorer/original_pike.yml plus
+ * internal/scorer/algorithm): each signal is clamped into [lower, upper], inverted when
+ * smaller_is_better, normalized as log(1+v)/log(1+threshold), then combined as a weighted
+ * arithmetic mean. A signal that cannot be collected is DROPPED from both the numerator
+ * and the denominator — same as upstream — so a partial run reports an optimistic score.
+ * That is why every dropped signal is printed loudly.
+ *
+ * Usage:
+ *   node scripts/openssf-criticality.mjs [owner/repo] [--json] [--mentions=N]
+ *
+ * A GITHUB_TOKEN (or GH_TOKEN) is strongly recommended: unauthenticated REST is 60
+ * req/hour and the commit-search endpoint used for github_mention_count requires auth.
+ */
+import { execSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+const asJson = args.includes("--json");
+const mentionsOverride = args
+  .find((a) => a.startsWith("--mentions="))
+  ?.split("=")[1];
+const slugArg = args.find((a) => !a.startsWith("--"));
+
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || "";
+
+/** Weights and bounds from config/scorer/original_pike.yml. */
+const INPUTS = [
+  { field: "created_since", weight: 1, upper: 120 },
+  { field: "updated_since", weight: 1, upper: 120, smallerIsBetter: true },
+  { field: "contributor_count", weight: 2, upper: 5000 },
+  { field: "org_count", weight: 1, upper: 10 },
+  { field: "commit_frequency", weight: 1, upper: 1000 },
+  { field: "recent_release_count", weight: 0.5, upper: 26 },
+  { field: "updated_issues_count", weight: 0.5, upper: 5000 },
+  { field: "closed_issues_count", weight: 0.5, upper: 5000 },
+  { field: "issue_comment_frequency", weight: 1, upper: 15 },
+  { field: "github_mention_count", weight: 2, upper: 500000 },
+];
+
+/** zipfian normalization, the only distribution original_pike.yml uses. */
+const zipf = (v) => Math.log(1 + v);
+
+/** Bounds.Apply + Input.Value from internal/scorer/algorithm/input.go. */
+function normalize(value, { upper, smallerIsBetter }) {
+  const lower = 0;
+  let v = Math.min(Math.max(value, lower), upper) - lower;
+  const threshold = upper - lower;
+  if (smallerIsBetter) v = threshold - v;
+  return zipf(v) / zipf(threshold);
+}
+
+function resolveSlug() {
+  if (slugArg) return slugArg;
+  const remote = execSync("git remote get-url origin", {
+    encoding: "utf8",
+  }).trim();
+  const m = remote.match(/github\.com[:/](.+?)(?:\.git)?$/);
+  if (!m) throw new Error(`Cannot parse a GitHub slug from origin: ${remote}`);
+  return m[1];
+}
+
+const API = "https://api.github.com";
+
+async function gh(path, { search = false } = {}) {
+  const res = await fetch(path.startsWith("http") ? path : API + path, {
+    headers: {
+      accept: search
+        ? "application/vnd.github.cloak-preview+json"
+        : "application/vnd.github+json",
+      "user-agent": "motiq-criticality-score",
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+  });
+  if (!res.ok) {
+    const err = new Error(`GitHub ${res.status} on ${path}`);
+    err.status = res.status;
+    throw err;
+  }
+  return { body: await res.json(), headers: res.headers };
+}
+
+/** Contributor count via the Link header's last page — avoids paging 5000 entries. */
+async function contributorCount(slug) {
+  const { body, headers } = await gh(
+    `/repos/${slug}/contributors?per_page=1&anon=1`,
+  );
+  const link = headers.get("link") || "";
+  const last = link.match(/[?&]page=(\d+)>; rel="last"/);
+  return last ? Number(last[1]) : body.length;
+}
+
+/** Distinct orgs across the top contributors, matching the legacy signal's intent. */
+async function orgCount(slug) {
+  const { body: contributors } = await gh(
+    `/repos/${slug}/contributors?per_page=25&anon=1`,
+  );
+  const logins = contributors.map((c) => c.login).filter(Boolean);
+  const orgs = new Set();
+  for (const login of logins) {
+    try {
+      const { body } = await gh(`/users/${login}/orgs?per_page=100`);
+      for (const o of body) orgs.add(o.login);
+    } catch {
+      // A user with private org membership simply contributes nothing here.
+    }
+  }
+  return orgs.size;
+}
+
+/** Average commits per week over the trailing year. */
+async function commitFrequency(slug) {
+  // /stats/* returns 202 with an empty body while GitHub computes the cache.
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const { body } = await gh(`/repos/${slug}/stats/commit_activity`);
+    if (Array.isArray(body) && body.length) {
+      const total = body.reduce((sum, w) => sum + w.total, 0);
+      return total / body.length;
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  throw new Error("commit_activity stats never materialized");
+}
+
+async function recentReleaseCount(slug) {
+  const { body } = await gh(`/repos/${slug}/releases?per_page=100`);
+  const yearAgo = Date.now() - 365 * 24 * 3600 * 1000;
+  return body.filter((r) => Date.parse(r.published_at ?? r.created_at) > yearAgo)
+    .length;
+}
+
+const iso = (daysAgo) =>
+  new Date(Date.now() - daysAgo * 24 * 3600 * 1000).toISOString().slice(0, 10);
+
+async function searchCount(q) {
+  const { body } = await gh(
+    `/search/issues?q=${encodeURIComponent(q)}&per_page=1`,
+  );
+  return body.total_count;
+}
+
+/**
+ * Comments per issue across issues touched in the last 90 days. Upstream divides total
+ * comments by the number of updated issues; with zero updated issues the signal is
+ * undefined rather than zero, so it is dropped.
+ */
+async function issueCommentFrequency(slug, updatedIssues) {
+  if (!updatedIssues) return null;
+  const { body } = await gh(
+    `/repos/${slug}/issues/comments?since=${iso(90)}&per_page=100`,
+  );
+  return body.length / updatedIssues;
+}
+
+async function collect(slug) {
+  const signals = {};
+  const dropped = [];
+  const record = async (field, fn) => {
+    try {
+      const v = await fn();
+      if (v === null || Number.isNaN(v)) dropped.push([field, "not applicable"]);
+      else signals[field] = v;
+    } catch (e) {
+      dropped.push([field, e.message]);
+    }
+  };
+
+  const { body: repo } = await gh(`/repos/${slug}`);
+  const months = (from) =>
+    (Date.now() - Date.parse(from)) / (30.4375 * 24 * 3600 * 1000);
+
+  signals.created_since = months(repo.created_at);
+  signals.updated_since = months(repo.pushed_at);
+
+  await record("contributor_count", () => contributorCount(slug));
+  await record("org_count", () => orgCount(slug));
+  await record("commit_frequency", () => commitFrequency(slug));
+  await record("recent_release_count", () => recentReleaseCount(slug));
+  await record("updated_issues_count", () =>
+    searchCount(`repo:${slug} is:issue updated:>=${iso(90)}`),
+  );
+  await record("closed_issues_count", () =>
+    searchCount(`repo:${slug} is:issue closed:>=${iso(90)}`),
+  );
+  await record("issue_comment_frequency", () =>
+    issueCommentFrequency(slug, signals.updated_issues_count),
+  );
+
+  if (mentionsOverride !== undefined) {
+    signals.github_mention_count = Number(mentionsOverride);
+  } else {
+    await record("github_mention_count", async () => {
+      const { body } = await gh(
+        `/search/commits?q=${encodeURIComponent(`"${slug}"`)}&per_page=1`,
+        { search: true },
+      );
+      return body.total_count;
+    });
+  }
+
+  return { repo, signals, dropped };
+}
+
+const slug = resolveSlug();
+const { signals, dropped } = await collect(slug);
+
+let numerator = 0;
+let denominator = 0;
+const rows = [];
+for (const input of INPUTS) {
+  const raw = signals[input.field];
+  if (raw === undefined) continue;
+  const n = normalize(raw, input);
+  numerator += input.weight * n;
+  denominator += input.weight;
+  rows.push({
+    field: input.field,
+    raw,
+    weight: input.weight,
+    upper: input.upper,
+    normalized: n,
+    contribution: (input.weight * n) / 10.5,
+  });
+}
+const score = denominator ? numerator / denominator : 0;
+
+if (asJson) {
+  console.log(
+    JSON.stringify({ repo: slug, score, rows, dropped, signals }, null, 2),
+  );
+} else {
+  const pad = (s, n) => String(s).padEnd(n);
+  console.log(`\nOpenSSF criticality score — ${slug}\n`);
+  console.log(
+    `  ${pad("signal", 26)}${pad("value", 12)}${pad("threshold", 11)}${pad("weight", 8)}headroom`,
+  );
+  console.log(`  ${"-".repeat(69)}`);
+  for (const r of rows) {
+    const value =
+      r.field.endsWith("_since") || r.field.endsWith("frequency")
+        ? r.raw.toFixed(2)
+        : r.raw;
+    console.log(
+      `  ${pad(r.field, 26)}${pad(value, 12)}${pad(r.upper, 11)}${pad(r.weight, 8)}${(
+        (1 - r.normalized) *
+        (r.weight / 10.5)
+      ).toFixed(4)}`,
+    );
+  }
+  console.log(`  ${"-".repeat(69)}`);
+  console.log(`\n  score: ${score.toFixed(5)}   (critical-infrastructure bar: 0.4)\n`);
+  if (dropped.length) {
+    console.log(
+      "  Dropped signals — upstream removes these from the denominator too, so the",
+    );
+    console.log("  score above is OPTIMISTIC by however much they would have cost:");
+    for (const [field, why] of dropped) console.log(`    - ${field}: ${why}`);
+    if (!token)
+      console.log(
+        "\n  Set GITHUB_TOKEN to collect the auth-only signals (commit search, org lookups).",
+      );
+    console.log("");
+  }
+}


### PR DESCRIPTION
Implements the OpenSSF Scorecard checks this repo can satisfy through configuration, and adds a way to measure the criticality score instead of guessing at it.

## Scorecard checks now covered

| Check | How |
|---|---|
| Scorecard | weekly run, publishes results to the OpenSSF API |
| SAST | CodeQL, `javascript-typescript`, `security-extended` |
| Dependency-Update-Tool | Dependabot, npm + github-actions |
| Pinned-Dependencies | actions pinned to commit SHAs |
| Token-Permissions | explicit least-privilege `permissions:` per workflow |

**The pins are behaviour-neutral.** Each SHA is the commit the floating `v4` tag already resolves to today — `checkout` v4.4.0, `setup-node` v4.4.0, `pnpm/action-setup` **v4.3.0** (the `v4` tag has not moved to v4.4.0 yet). CI runs the same code it ran before. The `github-actions` Dependabot updater is there to keep those pins from rotting, since a SHA is unreviewable by eye.

## Criticality score

Separate metric, frequently confused with Scorecard, and **not implementable** — it is a weighted mean of ten observed signals measuring how much the ecosystem depends on this repo. No file moves it.

`scripts/openssf-criticality.mjs` reimplements the upstream algorithm (`config/scorer/original_pike.yml` + `internal/scorer/algorithm`) against the GitHub API:

```bash
pnpm openssf:criticality
```

Baseline **0.215**. Recency is maxed; the binding constraints are contributor count (1), contributor orgs (0), issue traffic (0/90d) and downstream mentions (20 vs a 500k threshold) — all adoption, none of it CI's to fix.

## Deliberately not in this PR

- **Branch protection** — a repo setting, not a file. Worth doing *before* merge so the first published Scorecard number reflects it.
- **README badge** — `publish_results` must run on `main` once before the shields.io endpoint resolves. Check the real score at [scorecard.dev](https://scorecard.dev/viewer/?uri=github.com/RMahammad/motiq) after merge, then decide whether it earns a spot above the fold.
- **Signed-Releases / Packaging** — needs a publish workflow with npm provenance, and the changeset config still says `"access": "restricted"`. Open decision; requirement recorded in docs/17.

## Verification

`check-links`, `check-stale-dates`, `check-duplicate-titles`, `check-adr-index` and `pnpm lint` all pass locally. All four workflow YAMLs parse.

Note that Scorecard itself will **not** run on this PR — it only triggers on push to `main` and on schedule, because `publish_results` requires the default branch. CodeQL and the repinned `ci.yml` do run here.