### PR TITLE
fix(openssf): make the criticality script agree with the reference tool

### DIFF
--- a/docs/17-security-and-supply-chain.md
+++ b/docs/17-security-and-supply-chain.md
@@ -50,28 +50,35 @@ leaving on the table — which is the only useful way to read it. A signal that 
 collected is dropped from the denominator, exactly as upstream does, so a partial run
 reports an *optimistic* score; the script says which ones were dropped.
 
-Baseline on 2026-09-04, nine of ten signals collected: **0.215**.
+Baseline on 2026-09-05, all ten signals collected: **0.18891**.
 
 | signal | raw | normalized |
 |---|---|---|
-| created_since | 1.7 months | 0.21 |
-| updated_since | 0.8 months | 1.00 |
+| created_since | 1 month | 0.14 |
+| updated_since | 0 months | 1.00 |
 | contributor_count | 1 | 0.08 |
 | org_count | 0 | 0.00 |
-| commit_frequency | 0.35 / week | 0.04 |
+| commit_frequency | 0.37 / week | 0.05 |
 | recent_release_count | 2 | 0.33 |
 | updated_issues_count | 0 | 0.00 |
 | closed_issues_count | 0 | 0.00 |
+| issue_comment_frequency | 0 | 0.00 |
 | github_mention_count | 20 | 0.23 |
+
+Validated against the reference implementation — `go run
+github.com/ossf/criticality_score/v2/cmd/criticality_score@latest -depsdev-disable
+https://github.com/RMahammad/motiq` reports the same 0.18891 from the same signals. Run
+that whenever this script is changed; agreement to five decimal places is the only
+evidence the script is measuring the real thing.
 
 Recency is already maxed; everything else is adoption. The binding constraints are
 contributor count, contributor orgs, issue traffic, and downstream mentions — none of
 which CI can manufacture. Repo age accrues on its own schedule. This is the expected shape
 for a young single-maintainer project and is not a defect to be fixed in a workflow.
 
-(A run that drops a signal reports higher — 0.235 when commit-frequency stats were
-unavailable — because the dropped weight leaves the denominator. Compare runs only when
-the same signals were collected.)
+**Reading a partial run:** a signal that cannot be collected is dropped from the
+denominator, so a failed collection reports a *higher* score, not a lower one. Never
+compare two runs that collected different signals.
 
 ### Scorecard — what is implemented
 

--- a/scripts/openssf-criticality.mjs
+++ b/scripts/openssf-criticality.mjs
@@ -116,18 +116,25 @@ async function orgCount(slug) {
   return orgs.size;
 }
 
-/** Average commits per week over the trailing year. */
+/**
+ * Average commits per week over the trailing year.
+ *
+ * Counted from the commits endpoint via the Link header, NOT /stats/commit_activity.
+ * The stats endpoints answer 202 ("computing, ask again") and for a low-traffic repo can
+ * stay that way across many polls — which silently dropped the signal, and a dropped
+ * signal leaves the denominator, so an impatient run reported a HIGHER score. Counting
+ * commits is deterministic and reproduces upstream exactly (19 commits / 52 = 0.37).
+ */
 async function commitFrequency(slug) {
-  // /stats/* returns 202 with an empty body while GitHub computes the cache.
-  for (let attempt = 0; attempt < 4; attempt += 1) {
-    const { body } = await gh(`/repos/${slug}/stats/commit_activity`);
-    if (Array.isArray(body) && body.length) {
-      const total = body.reduce((sum, w) => sum + w.total, 0);
-      return total / body.length;
-    }
-    await new Promise((r) => setTimeout(r, 2000));
-  }
-  throw new Error("commit_activity stats never materialized");
+  const since = new Date(Date.now() - 365 * 24 * 3600 * 1000).toISOString();
+  const { body, headers } = await gh(
+    `/repos/${slug}/commits?since=${since}&per_page=1`,
+  );
+  const last = (headers.get("link") || "").match(/[?&]page=(\d+)>; rel="last"/);
+  // One page of one item means Link is absent: 0 or 1 commits, and body says which.
+  const perWeek = (last ? Number(last[1]) : body.length) / 52;
+  // Upstream rounds this signal to 2dp before scoring; without it we land 0.00005 low.
+  return Math.round(perWeek * 100) / 100;
 }
 
 async function recentReleaseCount(slug) {
@@ -153,7 +160,9 @@ async function searchCount(q) {
  * undefined rather than zero, so it is dropped.
  */
 async function issueCommentFrequency(slug, updatedIssues) {
-  if (!updatedIssues) return null;
+  // Upstream emits 0 here rather than omitting the signal, which keeps weight 1 in the
+  // denominator. Dropping it instead was worth ~+0.02 of pure inflation.
+  if (!updatedIssues) return 0;
   const { body } = await gh(
     `/repos/${slug}/issues/comments?since=${iso(90)}&per_page=100`,
   );
@@ -177,8 +186,10 @@ async function collect(slug) {
   const months = (from) =>
     (Date.now() - Date.parse(from)) / (30.4375 * 24 * 3600 * 1000);
 
-  signals.created_since = months(repo.created_at);
-  signals.updated_since = months(repo.pushed_at);
+  // Upstream reports these as WHOLE months (legacy.created_since: 1 for a 1.7-month-old
+  // repo). Keeping the fraction inflated the score against the reference implementation.
+  signals.created_since = Math.floor(months(repo.created_at));
+  signals.updated_since = Math.floor(months(repo.pushed_at));
 
   await record("contributor_count", () => contributorCount(slug));
   await record("org_count", () => orgCount(slug));


### PR DESCRIPTION
Cross-checked `scripts/openssf-criticality.mjs` against the real thing:

```
go run github.com/ossf/criticality_score/v2/cmd/criticality_score@latest \
  -depsdev-disable https://github.com/RMahammad/motiq
```

The **formula was already exact** — fed upstream's own collected signals it reproduces upstream's output to five decimals. Three bugs in signal *collection*, all inflating the result:

| Bug | Effect |
|---|---|
| `created_since` / `updated_since` kept fractional months | upstream reports whole months (1, not 1.71) |
| `issue_comment_frequency` dropped when no issues touched | upstream emits `0`, keeping weight 1 in the denominator — dropping it removed the weight, ~+0.02 inflation |
| `commit_frequency` read `/stats/commit_activity` | that endpoint answers 202 while GitHub builds its cache and, on a low-traffic repo, stays that way across every poll |

**The common thread is the trap in this metric:** a dropped signal leaves the *denominator*, so a run that fails to collect something reports a **higher** score. Two of these bugs made the repo look more critical than it is, silently.

`commit_frequency` now counts commits over the trailing year (19 / 52 = 0.37), which is deterministic and matches upstream exactly.

Reported baseline: **0.215 → 0.18891**, now identical to the reference tool. docs/17 records the cross-check command so future changes can be validated the same way.