### PR TITLE
chore(deps): retune Dependabot after the first run produced unmergeable PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,26 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
     groups:
-      # One PR per ecosystem-wide bump keeps review load proportional to risk: dev
-      # tooling churns constantly and is not shipped to users.
+      # PATCH ONLY, deliberately. The first run grouped 10 dev-dep updates into one PR
+      # and it failed CI, because "minor" is not a safety guarantee below 1.0: the group
+      # carried tsdown 0.15.12 -> 0.22.14, which broke @scope/tokens#build, and the nine
+      # harmless bumps around it made that invisible. Under semver a 0.x minor IS a
+      # breaking change, and several build-critical tools here (tsdown, publint,
+      # @arethetypeswrong/cli) are 0.x. Patch-only grouping keeps the batch genuinely
+      # low-risk; every minor now arrives as its own PR that can be read and reverted
+      # on its own.
       dev-dependencies:
         dependency-type: development
-        update-types: [minor, patch]
+        update-types: [patch]
+
+    ignore:
+      # engines pins Node >=22.13 and CI proves that floor via .nvmrc. Typing against
+      # Node 26 APIs while shipping support for 22 gets the dependency backwards: it
+      # hides breakage from the version we actually support. Track the runtime, not
+      # the newest types.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+
     labels: [dependencies]
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
The config from #11 was theoretically fine and practically wrong. The first run opened nine PRs; two could not be merged, and both were config's fault rather than Dependabot's.

### 1. Group patch-only, not `minor + patch`

`#16` bundled ten dev-dep updates into one PR and failed CI. The culprit was **tsdown 0.15.12 → 0.22.14**, which broke `@scope/tokens#build`.

Below 1.0, a *minor* bump **is** a breaking change, and several build-critical tools here are 0.x — `tsdown`, `publint`, `@arethetypeswrong/cli`. Grouping them alongside nine harmless patch bumps hid the one that mattered inside a batch that looked routine.

Patch-only keeps the grouped PR genuinely low-risk. Minors now arrive individually, where a red check points at its own cause.

### 2. Ignore major bumps of `@types/node`

`#17` offered 22.20.1 → **26.4.1**, while `engines` pins `node >=22.13` and CI proves that floor from `.nvmrc`. Typing against Node 26 APIs while shipping support for 22 gets the dependency backwards — it hides breakage from the version users actually run. Types should track the runtime, not lead it.

### After this lands

- `#17` closes itself — Dependabot drops PRs that a new `ignore` rule covers.
- `#16` regenerates without the breaking member; `tsdown` comes back as its own reviewable PR.
- No action needed on `#12`–`#15` or `#19`, which are green and unaffected.

### Scope

This changes only *which* PRs get opened. It does not touch the separate Dependabot **security-update** stream — now enabled on the repo — which is what produces fixes for the 26 OSV findings behind Scorecard's `Vulnerabilities: 0`.