### PR TITLE
feat(ci): attach Sigstore build provenance to published releases

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,85 @@
+# Attaches BUILD PROVENANCE to every published release, satisfying the OpenSSF Scorecard
+# "Signed-Releases" check — and, more usefully, letting anyone verify that a tarball they
+# hold was built by this workflow from this repository at a specific commit.
+#
+# Scope note: this is NOT the publish pipeline. docs/18 still blocks `changeset publish`
+# on the packaging decision (packages are "private": true, registry undecided). Signing
+# the artifacts of releases we already cut does not depend on that decision, so it lands
+# separately rather than waiting.
+#
+# What a consumer can do with the result:
+#   gh attestation verify scope-react-<version>.tgz --repo RMahammad/motiq
+#
+# The uploaded .intoto.jsonl bundle is the same attestation in offline form — for anyone
+# verifying without the GitHub API, and for Scorecard, which reads release assets.
+name: Release artifacts
+
+on:
+  release:
+    types: [published]
+  # Backfill: attach artifacts to a release that predates this workflow. The tarballs are
+  # built fresh from that tag now, and the attestation says exactly that — it does not
+  # claim to describe a build that happened at release time.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to build and attach artifacts to"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  npm_config_verify_deps_before_run: "false"
+
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # upload assets onto the release
+      id-token: write # Sigstore OIDC — the identity the attestation is bound to
+      attestations: write # write into GitHub's attestation store
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+
+      # tokens/motion/react are the publishable three — the same set
+      # fixtures/tarball-consumer/verify.sh packs and CI already proves installable.
+      # Keep these two lists in step.
+      - name: Pack publishable packages
+        run: |
+          mkdir -p dist-artifacts
+          for p in tokens motion react; do
+            (cd "packages/$p" && pnpm pack --pack-destination "$GITHUB_WORKSPACE/dist-artifacts")
+          done
+          ls -l dist-artifacts
+
+      - name: Attest build provenance
+        id: attest
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: dist-artifacts/*.tgz
+
+      - name: Attach artifacts + provenance to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+        run: |
+          # Scorecard reads release ASSETS, so the bundle is uploaded alongside the
+          # tarballs rather than left only in GitHub's attestation store. The
+          # .intoto.jsonl suffix is what marks it as provenance.
+          cp "${{ steps.attest.outputs.bundle-path }}" "dist-artifacts/${TAG}.intoto.jsonl"
+          gh release upload "$TAG" dist-artifacts/*.tgz "dist-artifacts/${TAG}.intoto.jsonl" --clobber

--- a/docs/17-security-and-supply-chain.md
+++ b/docs/17-security-and-supply-chain.md
@@ -111,6 +111,7 @@ of the lockfile installs. Treat adding one as a decision, not a chore.
 | Token-Permissions | ✅ explicit `permissions:` per workflow | all workflows |
 | Dangerous-Workflow | ✅ no `pull_request_target`, no untrusted checkout | — |
 | Scorecard itself | ✅ weekly, results published | [`scorecard.yml`](../.github/workflows/scorecard.yml) |
+| Signed-Releases | ✅ Sigstore build provenance on every published release | [`release-artifacts.yml`](../.github/workflows/release-artifacts.yml) |
 
 The README badge is deliberately **not** added yet. `publish_results` has to run on the
 default branch once before `img.shields.io/ossf-scorecard/...` resolves to anything, and
@@ -120,15 +121,22 @@ belongs above the fold.
 
 ### Scorecard — what is not, and why
 
-- **Branch-Protection** — a repository *setting*, not a file. Requires, on `main`: require
-  a PR before merging, require status checks (`verify`, `fixtures`), and dismiss stale
-  approvals. Must be set by the owner in repo settings.
-- **Signed-Releases / Packaging** — needs a publish workflow with npm provenance
-  (`npm publish --provenance`, `id-token: write`). Deliberately not written yet: the
-  changeset config still declares `"access": "restricted"`, so the publishing target is an
-  open decision ([`18`](18-release-process.md)). Provenance is the requirement recorded above.
-- **Code-Review** — needs a second reviewer on merged PRs. Structurally unavailable to a
-  single maintainer; will improve only with contributors.
+- **Branch-Protection** — capped by choice, not neglect. The `main-guardrails` and
+  `main-protection` rulesets already block deletion and force-pushes and require the
+  `verify` + `fixtures` checks, and stale-review dismissal is on. The remaining points
+  need `required_approving_review_count >= 1` **with the RepositoryRole bypass removed** —
+  which, with one maintainer, means no PR can ever be merged, security fixes included.
+  A score of 3–4 is the honest ceiling here until there is a second reviewer.
+- **Packaging** — still open. Needs a real publish workflow, and the changeset config
+  still declares `"access": "restricted"` with every package `"private": true`, so the
+  publishing target is an undecided product question ([`18`](18-release-process.md)).
+  `npm publish --provenance` is the recorded requirement for when it is decided.
+- **Code-Review** — needs a human other than the author to approve merged PRs. GitHub
+  does not permit approving your own pull request, so with one maintainer this check
+  cannot be earned, and it will stay 0 until there is a second reviewer. It must not be
+  worked around with a second account: the score is consumed by downstream users as a
+  claim about how this project actually operates, and a fabricated approval trail is a
+  false claim, not a passing grade.
 - **Contributors** — needs contributors from ≥ 2 organizations. Same constraint.
 - **Fuzzing** — not pursued. This is a presentational component library with no parser and
   no untrusted input surface; a fuzzer here would buy points, not safety.

--- a/docs/18-release-process.md
+++ b/docs/18-release-process.md
@@ -40,6 +40,10 @@ Driven by [`release-readiness`](../.claude/skills/registry-release/SKILL.md) and
 - [ ] Migration guide present for any breaking change.
 - [ ] `npm publish --provenance`; 2FA; least-privilege token ([`17`](17-security-and-supply-chain.md)).
 - [ ] Git tag + GitHub release notes.
+- [ ] Release published → [`release-artifacts.yml`](../.github/workflows/release-artifacts.yml)
+      attaches the packed `tokens`/`motion`/`react` tarballs plus a Sigstore provenance
+      bundle. Verify one before announcing:
+      `gh attestation verify scope-react-<version>.tgz --repo RMahammad/motiq`.
 - [ ] Go/no-go report produced.
 
 ## Rollback


### PR DESCRIPTION
Scorecard: `Signed-Releases 0/10` — *"Project has not signed or included provenance with any releases."*

## I had this filed wrong

I previously grouped `Signed-Releases` with `Packaging` as blocked on the publishing decision. Only **`Packaging`** needs a registry target. Signing the artifacts of releases you already cut depends on nothing — so it lands now instead of waiting on a product question.

## What it does

On a published release: build → pack `tokens`/`motion`/`react` (the same three `fixtures/tarball-consumer/verify.sh` already proves installable) → attest with `actions/attest-build-provenance` → upload tarballs + bundle to the release.

Anyone can then verify:

```bash
gh attestation verify scope-react-<version>.tgz --repo RMahammad/motiq
```

The `.intoto.jsonl` bundle is uploaded as a release **asset**, not just left in GitHub's attestation store — that's where Scorecard looks, and it lets people verify offline.

## This will not move the score today

Scorecard reads the most recent releases, and v0.1.0 / v0.2.0 have no signed artifacts. The score moves on the **next** release.

`workflow_dispatch` takes a tag so those two can be backfilled if you want the points sooner. Be aware what that means: the tarballs are built fresh from the tag now, and the attestation says exactly that — it does not pretend to describe a build that happened at release time. Your call whether that's worth doing.

Also worth knowing: v0.1.0's existing assets are `.mp4` and `.gif` promo files. Scorecard flags them as unsigned "release artifacts" because it can't tell marketing media from software. Signing a promo GIF would tick the box and improve nothing; attaching real, verifiable tarballs is the version of this that's actually worth having.

## Doc corrections

`docs/17` was overstating two things:

- **Branch-Protection** is capped by *choice*, not neglect. Deletion, force-push and required checks are already enforced; the remaining points need a required approver with no admin bypass, which would lock a single maintainer out of their own repository — security fixes included. 3–4 is the honest ceiling.
- **Code-Review** cannot be earned here at all. GitHub does not permit approving your own PR, so it stays 0 until there is a second reviewer. Noted explicitly that a second account is not an acceptable workaround: the score is read by downstream users as a claim about how the project actually operates.