### PR TITLE
fix(ci): correct the release backfill claim — old tags cannot be signed

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -17,13 +17,17 @@ name: Release artifacts
 on:
   release:
     types: [published]
-  # Backfill: attach artifacts to a release that predates this workflow. The tarballs are
-  # built fresh from that tag now, and the attestation says exactly that — it does not
-  # claim to describe a build that happened at release time.
+  # Backfill, with a hard limit worth knowing before you reach for it: this checks out the
+  # TAG, so it runs that tag's toolchain. v0.1.0 and v0.2.0 both pin "pnpm@11.13.0" — the
+  # broken release whose "@pnpm/exe" ships no binary — so a dispatch against either dies
+  # at pnpm/action-setup with ERR_PNPM_BROKEN_PNPM_RELEASE before anything is built.
+  # Tried on v0.2.0; it fails, and uploads nothing. Only tags cut after the pnpm fix
+  # (a095a2c) can be backfilled. Signed-Releases therefore moves on the next RELEASE,
+  # not by retrofitting the old ones.
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing release tag to build and attach artifacts to"
+        description: "Release tag to build and attach artifacts to (must post-date a095a2c)"
         required: true
         type: string
 

--- a/docs/17-security-and-supply-chain.md
+++ b/docs/17-security-and-supply-chain.md
@@ -111,13 +111,20 @@ of the lockfile installs. Treat adding one as a decision, not a chore.
 | Token-Permissions | ✅ explicit `permissions:` per workflow | all workflows |
 | Dangerous-Workflow | ✅ no `pull_request_target`, no untrusted checkout | — |
 | Scorecard itself | ✅ weekly, results published | [`scorecard.yml`](../.github/workflows/scorecard.yml) |
-| Signed-Releases | ✅ Sigstore build provenance on every published release | [`release-artifacts.yml`](../.github/workflows/release-artifacts.yml) |
+| Signed-Releases | ⏳ workflow ready; scores on the **next** release | [`release-artifacts.yml`](../.github/workflows/release-artifacts.yml) |
 
 The README badge is deliberately **not** added yet. `publish_results` has to run on the
 default branch once before `img.shields.io/ossf-scorecard/...` resolves to anything, and
 the first score will be held down by the four checks below. Read the real number at
 <https://scorecard.dev/viewer/?uri=github.com/RMahammad/motiq>, then decide whether it
 belongs above the fold.
+
+**Signed-Releases scores releases, not workflows.** Merging the workflow does nothing to
+the number; the check reads the assets on recent releases, and v0.1.0 and v0.2.0 carry
+only promo media. It cannot be retrofitted either: both tags pin the broken
+`pnpm@11.13.0`, so a build from them fails at install (verified — the dispatch errors with
+`ERR_PNPM_BROKEN_PNPM_RELEASE` and uploads nothing). The check moves the first time a
+release is cut from a commit after the pnpm fix.
 
 ### Scorecard — what is not, and why
 


### PR DESCRIPTION
#29 advertised `workflow_dispatch` as a way to retrofit provenance onto an existing release. I tried it against v0.2.0. It cannot work.

The dispatch checks out the **tag**, so it runs that tag's toolchain — and both v0.1.0 and v0.2.0 pin `pnpm@11.13.0`, the broken release whose `@pnpm/exe` ships no binary. The same one that was breaking Vercel:

```
[ERR_PNPM_BROKEN_PNPM_RELEASE] pnpm v11.13.0 is a broken release and cannot be installed
```

It dies at `pnpm/action-setup` before anything is built and uploads nothing, so v0.2.0 is untouched. Only tags cut after the pnpm fix (`a095a2c`) can be backfilled.

**Consequence: `Signed-Releases` moves on the next release and cannot be retrofitted.**

`docs/17` also drops the ✅ it was already claiming for `Signed-Releases`. The check reads assets on recent releases, not the presence of a workflow — merging #29 moved the score by exactly zero, which is what that table should have said to begin with.