### PR TITLE
fix(ci): let Scorecard be re-run on demand

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,6 +17,11 @@ on:
     - cron: "27 4 * * 1" # Mondays; off the hour to avoid the scheduler stampede
   push:
     branches: [main]
+  # Some checks grade things that never touch main. Signed-Releases reads the assets on
+  # published releases, and publishing a release pushes no commit — so cutting v0.3.0
+  # with signed artifacts left the public score reporting the pre-release state until the
+  # next unrelated merge happened to re-trigger this. Manual dispatch closes that gap.
+  workflow_dispatch:
 
 # Least privilege at the workflow level; the one job that needs more declares it.
 permissions: read-all

--- a/docs/17-security-and-supply-chain.md
+++ b/docs/17-security-and-supply-chain.md
@@ -111,7 +111,7 @@ of the lockfile installs. Treat adding one as a decision, not a chore.
 | Token-Permissions | ✅ explicit `permissions:` per workflow | all workflows |
 | Dangerous-Workflow | ✅ no `pull_request_target`, no untrusted checkout | — |
 | Scorecard itself | ✅ weekly, results published | [`scorecard.yml`](../.github/workflows/scorecard.yml) |
-| Signed-Releases | ⏳ workflow ready; scores on the **next** release | [`release-artifacts.yml`](../.github/workflows/release-artifacts.yml) |
+| Signed-Releases | ✅ v0.3.0 ships signed tarballs + provenance | [`release-artifacts.yml`](../.github/workflows/release-artifacts.yml) |
 
 The README badge is deliberately **not** added yet. `publish_results` has to run on the
 default branch once before `img.shields.io/ossf-scorecard/...` resolves to anything, and
@@ -119,12 +119,20 @@ the first score will be held down by the four checks below. Read the real number
 <https://scorecard.dev/viewer/?uri=github.com/RMahammad/motiq>, then decide whether it
 belongs above the fold.
 
-**Signed-Releases scores releases, not workflows.** Merging the workflow does nothing to
-the number; the check reads the assets on recent releases, and v0.1.0 and v0.2.0 carry
-only promo media. It cannot be retrofitted either: both tags pin the broken
-`pnpm@11.13.0`, so a build from them fails at install (verified — the dispatch errors with
-`ERR_PNPM_BROKEN_PNPM_RELEASE` and uploads nothing). The check moves the first time a
-release is cut from a commit after the pnpm fix.
+**Signed-Releases scores releases, not workflows** — and the published score lags them.
+The check reads assets on recent releases; v0.1.0 and v0.2.0 carry only promo media and
+cannot be retrofitted, because both tags pin the broken `pnpm@11.13.0` and fail at install
+(verified: the dispatch errors with `ERR_PNPM_BROKEN_PNPM_RELEASE` and uploads nothing).
+v0.3.0 is the first release with signed artifacts:
+
+```bash
+gh attestation verify scope-motion-0.3.0.tgz --repo RMahammad/motiq
+```
+
+Note the reporting lag that caused real confusion here. Publishing a release pushes no
+commit, so it does not re-trigger `scorecard.yml` — the public score kept reporting the
+pre-release state after v0.3.0 shipped. `workflow_dispatch` on that workflow is the fix;
+run it after any release, or the score waits for the Monday cron or the next merge.
 
 ### Scorecard — what is not, and why
 


### PR DESCRIPTION
v0.3.0 shipped with signed tarballs and a Sigstore provenance bundle — and the public score kept reporting `Signed-Releases: 0` for hours afterwards.

**Nothing was broken.** The release workflow ran (1m9s, success) and attached:

```
scope-motion-0.3.0.tgz   scope-react-0.2.1.tgz
scope-tokens-0.2.0.tgz   v0.3.0.intoto.jsonl
```

and the attestation verifies against Sigstore:

```
subject : scope-motion-0.3.0.tgz
builder : .../release-artifacts.yml@refs/tags/v0.3.0
commit  : 37d45f95b8d19e8ce8f307e94b53c19774584845
```

## The actual gap

`scorecard.yml` re-runs only on **push to main**, the Monday cron, or a branch-protection change. Publishing a release pushes no commit — so the grade stayed pinned to a pre-release scan of `428d3c2` (23:47 Sep 4), eight hours before the release went out at 07:18 Sep 5.

A stale number reads exactly like a failure, which is what happened here.

`workflow_dispatch` makes the re-grade explicit instead of something you wait for. Merging this also pushes to `main`, which re-triggers the scan that should have followed the release.

`docs/17` records the lag, because "the score didn't move" will look like a bug every time until someone knows to expect it.